### PR TITLE
Integrate PT-Portal bookings access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,49 @@
+# Bookings portal -> PT-Portal integration
+# Use HTTPS outside local development and omit the trailing slash.
+PT_PORTAL_BASE_URL=https://pt-portal.example.com
+PT_PORTAL_REQUEST_TIMEOUT_MS=10000
+
+# Server-only. Generate a unique value with at least 32 random characters.
+# Used to encrypt the hardened HttpOnly package-session cookie. It is deliberately
+# blank here so this example cannot accidentally become a valid production key.
+PACKAGE_PORTAL_SESSION_SECRET=
+
+# Optional future server-to-server request signing. The current code does not
+# send this value, so leave it unset until both portals support request signing.
+# PT_PORTAL_INTEGRATION_SECRET=replace-with-a-shared-random-secret
+
+# Legacy Firebase Admin credentials used by Vercel serverless functions.
+# Preserve the literal \n sequences in FIREBASE_PRIVATE_KEY.
+FIREBASE_PROJECT_ID=piyam-travel-bookings
+FIREBASE_CLIENT_EMAIL=firebase-adminsdk@example-project.iam.gserviceaccount.com
+FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nreplace-with-private-key\n-----END PRIVATE KEY-----\n"
+
+# Legacy Firebase browser configuration.
+# These values are public browser configuration, not secrets. The current
+# src/firebase.js configuration is hardcoded and does not yet read these values.
+VITE_FIREBASE_API_KEY=replace-with-public-firebase-api-key
+VITE_FIREBASE_AUTH_DOMAIN=example-project.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=example-project
+VITE_FIREBASE_STORAGE_BUCKET=example-project.appspot.com
+VITE_FIREBASE_MESSAGING_SENDER_ID=123456789012
+VITE_FIREBASE_APP_ID=1:123456789012:web:replace-with-app-id
+VITE_FIREBASE_MEASUREMENT_ID=G-REPLACE123
+
+# Legacy Cloudflare R2 server credentials and public document base URL.
+R2_ACCESS_KEY_ID=replace-with-r2-access-key
+R2_SECRET_ACCESS_KEY=replace-with-r2-secret-key
+R2_BUCKET_NAME=piyam-travel-documents
+R2_PUBLIC_URL=https://documents.example.com
+
+# CLOUDFLARE_ACCOUNT_ID appeared in older setup notes but is not currently read
+# by the application because the R2 endpoint is configured in the API modules.
+# CLOUDFLARE_ACCOUNT_ID=replace-with-cloudflare-account-id
+
+# Legacy Mailgun completion-email configuration.
+MAILGUN_API_KEY=replace-with-mailgun-api-key
+MAILGUN_DOMAIN=mg.example.com
+MAILGUN_SENDER_EMAIL="Piyam Travel <noreply@example.com>"
+
+# Protects the scheduled legacy-folder purge endpoint. Configure the same value
+# as the CRON_SECRET GitHub Actions repository secret.
+CRON_SECRET=replace-with-a-long-random-cron-secret

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build production bundle
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,15 @@ dist
 dist-ssr
 *.local
 
+# Local environment files can contain server credentials.
+.env
+.env.*
+!.env.example
+!.env.*.example
+
+# Local Vercel project metadata.
+.vercel
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/Bookings portal integration.md
+++ b/Bookings portal integration.md
@@ -1,0 +1,902 @@
+# Bookings Portal Integration for PT-Portal Packages
+
+**Status:** Repository implementation complete; deployment and live acceptance pending
+
+**Created:** August 8, 2026
+
+**Implementation checkpoint:** August 8, 2026
+
+**Customer Portal:** `https://bookings.piyamtravel.com`
+
+**Customer Portal Repo:** `Piyam-Travel-LTD/piyam-travel-bookings-portal`
+
+**Package Operations Repo:** `Piyam-Travel-LTD/pt-portal`
+
+**Related Plan:** `TRAVEL_PACKAGE_QUOTATION_RESERVATION_WORKFLOW_PLAN.md`
+
+The repository now implements the Phase 1 and Phase 2 customer experience plus the secure cookie/session portion of Phase 3. Automated server, adapter, session, and client-contract tests pass together with the production build through `npm run check`.
+
+The remaining release gates require access outside this checkout: configure and deploy Vercel Preview/Production; validate a real released PT package, QR link, and legacy fallback; confirm revoked or disabled PT packages cannot reopen stale legacy data; confirm PT-Portal rate-limit identity when requests arrive through the bookings proxy; and approve Vercel edge-log handling for the initial token-bearing route. Track those checks in `docs/deployment-checklist.md`; repository build success alone does not complete the production release.
+
+---
+
+## 1. Purpose
+
+The existing bookings portal must be updated so customers can open packages created and managed in PT-Portal without losing access to legacy Firebase customer folders during the transition.
+
+PT-Portal is now the operational source of truth for new packages. It owns:
+
+- package references
+- customer identity used for portal access
+- package dates and public summary
+- document release status
+- released flight, hotel, visa, transport, insurance, E-Sim, invoice, and other files
+- released invoice snapshots
+- released transport vouchers
+- MinIO document storage and signed file URLs
+- portal access enablement and expiry
+- access audit records
+
+The bookings portal should remain the customer-facing website at `bookings.piyamtravel.com`. It should no longer create or manage new package folders. Its agent functionality can remain temporarily for legacy records, but all new operational work belongs in PT-Portal.
+
+The intended result is:
+
+```text
+Agent creates and manages package in PT-Portal
+-> Package is converted with reference PT-XXXXXX
+-> Agent releases selected documents and enables customer access
+-> Customer opens bookings.piyamtravel.com
+-> Customer enters PT reference and lead passenger surname
+-> Bookings portal loads the package from PT-Portal
+-> Customer previews/downloads only released documents
+-> Legacy Firebase customers continue to work during migration
+```
+
+---
+
+## 2. Existing Bookings Portal Architecture
+
+The current `piyam-travel-bookings-portal` repository uses:
+
+- React 18
+- Vite 5
+- React Router 6
+- Tailwind CSS
+- Firebase Authentication for agents
+- Firestore for customer folders
+- Cloudflare R2 for legacy documents
+- Vercel serverless functions
+- Zustand for agent-side state
+
+Relevant current files:
+
+```text
+src/App.jsx
+src/components/ClientPortal.jsx
+src/components/AgentDashboard.jsx
+src/firebase.js
+src/data.js
+api/lookup-customer.js
+vercel.json
+```
+
+Current customer flow:
+
+```text
+POST /api/lookup-customer
+-> Query Firestore customers by PT reference and lowercase surname
+-> Return the complete legacy customer object
+-> ClientPortal renders legacy documents and checklist
+```
+
+Current application routes:
+
+```text
+/        Customer document login and portal
+/agent   Legacy Firebase agent dashboard
+```
+
+Missing route required by PT-Portal:
+
+```text
+/package-documents/:token
+```
+
+PT-Portal already generates customer document URLs and transport voucher QR codes using this route shape.
+
+---
+
+## 3. Ownership Boundary
+
+### 3.1 PT-Portal Owns New Package Data
+
+The bookings portal must not connect directly to the PT-Portal Supabase database and must never receive the Supabase service role key.
+
+For new packages, PT-Portal remains responsible for:
+
+- validating the package reference and surname
+- rate limiting failed login attempts
+- checking whether customer access is enabled
+- checking portal expiry
+- deciding which documents are customer-visible
+- deciding whether an invoice is released
+- deciding whether a transport voucher is released
+- generating short-lived MinIO URLs
+- removing internal notes and supplier allocation data
+- recording portal access
+
+The bookings portal is responsible for:
+
+- the login and customer-facing interface
+- routing between PT-Portal and legacy Firebase records
+- rendering package data returned by PT-Portal
+- document preview and download controls
+- mobile usability
+- session/logout behaviour
+- friendly customer error states
+
+### 3.2 Legacy Firebase Remains Readable During Transition
+
+The current Firestore lookup should remain available until legacy records have been automatically migrated and validated.
+
+Do not create a second copy of new PT-Portal packages in Firebase. That would create two sources of truth and allow document release state to drift.
+
+---
+
+## 4. Required Customer Routes
+
+### 4.1 `/`
+
+The existing login page remains the main entry point.
+
+Required fields:
+
+- package reference
+- lead passenger surname
+
+The reference input should continue to display the `PT-` prefix and accept the six-character code. It should also tolerate customers pasting the full reference.
+
+Examples that must normalize to the same reference:
+
+```text
+H29GPX
+PT-H29GPX
+pt-h29gpx
+PT-H29GPX
+```
+
+### 4.2 `/package-documents/:token`
+
+This route is required for:
+
+- QR codes on transport vouchers
+- access vouchers generated in PT-Portal
+- direct document portal links copied by agents
+
+The token is an opaque access credential. The client must not parse it, convert it to a package reference, or expose it in logs.
+
+On direct navigation, the route should:
+
+1. read the token from React Router
+2. call the bookings portal serverless proxy
+3. load the current package from PT-Portal
+4. display the same customer dashboard used after reference/surname login
+5. show an expired or revoked message when access is unavailable
+
+### 4.3 `/agent`
+
+Keep the existing Firebase agent dashboard during the migration period, but display a clear internal notice:
+
+```text
+Legacy package folders only. Create and manage new packages in PT-Portal.
+```
+
+New package creation should eventually be removed from this page after migration sign-off.
+
+---
+
+## 5. Integration Architecture
+
+The customer browser should call only `bookings.piyamtravel.com` endpoints.
+
+```text
+Customer browser
+    |
+    v
+bookings.piyamtravel.com/api/package-access
+    |
+    +--> PT-Portal /api/package-portal/access
+    |
+    +--> Legacy /api/lookup-customer fallback on a genuine 404 only
+
+Customer browser
+    |
+    v
+bookings.piyamtravel.com/api/package-data
+    |
+    v
+PT-Portal /api/package-documents/:token
+    |
+    +--> Supabase release metadata
+    +--> MinIO signed preview/download URLs
+    +--> released invoice snapshot
+    +--> released transport voucher
+```
+
+This server-side proxy design is preferred because it:
+
+- avoids browser CORS dependency between the two domains
+- prevents the PT-Portal API base URL becoming part of every component
+- provides one place for legacy/new source routing
+- allows secure session cookies
+- allows future service-to-service request signing
+- keeps Supabase and storage credentials out of the bookings portal browser
+
+---
+
+## 6. PT-Portal APIs Already Available
+
+### 6.1 Reference and Surname Access
+
+```http
+POST {PT_PORTAL_BASE_URL}/api/package-portal/access
+Content-Type: application/json
+```
+
+Request:
+
+```json
+{
+  "reference": "PT-H29GPX",
+  "lastName": "Tariq"
+}
+```
+
+Success:
+
+```json
+{
+  "token": "opaque-package-document-token"
+}
+```
+
+Current error behaviour:
+
+| Status | Meaning | Bookings portal action |
+|---|---|---|
+| `400` | Missing or invalid input | Show validation error |
+| `404` | No matching active PT package | Try legacy Firebase lookup |
+| `410` | Matching package access expired | Show expiry message; do not use legacy fallback |
+| `429` | Too many failed attempts | Show retry-later message; do not use legacy fallback |
+| `500` | PT-Portal unavailable | Show temporary service error; do not report invalid details |
+
+PT-Portal currently limits repeated failed access attempts by hashed IP address and records successful customer portal access in the package audit log.
+
+### 6.2 Package Data by Token
+
+```http
+GET {PT_PORTAL_BASE_URL}/api/package-documents/{token}
+```
+
+Success response:
+
+```json
+{
+  "package": {
+    "id": "uuid",
+    "package_reference": "PT-H29GPX",
+    "customer_name": "Sobia Tariq",
+    "customer_email": "customer@example.com",
+    "package_type": "umrah",
+    "destination": "Makkah and Madinah",
+    "departure_date": "2026-08-10",
+    "return_date": "2026-08-16",
+    "document_access_expires_at": "2027-06-10T00:00:00.000Z",
+    "document_release_status": "released",
+    "current_public_summary": {},
+    "passport_status": "ready"
+  },
+  "documents": [],
+  "releasedInvoice": null,
+  "transportVoucher": null,
+  "signedUrlExpiresIn": 900
+}
+```
+
+Only documents satisfying both conditions are returned:
+
+```text
+customer_visible = true
+status = released
+```
+
+Each returned document includes:
+
+```text
+id
+category
+title
+file_name
+file_size
+file_type
+released_at
+public_notes
+metadata
+signed_url
+preview_url
+```
+
+`signed_url` is for download. `preview_url` uses inline content disposition. Both expire after 15 minutes and must be refreshed by reloading package data when expired.
+
+Current token errors:
+
+| Status | Meaning |
+|---|---|
+| `400` | Token missing |
+| `404` | Token invalid, access revoked, or package unavailable |
+| `410` | Access expired |
+| `500` | Package or storage lookup failed |
+
+---
+
+## 7. Bookings Portal Serverless Adapter
+
+### 7.1 New `api/package-access.js`
+
+Responsibilities:
+
+1. normalize the submitted reference
+2. call PT-Portal first
+3. return a PT package session on success
+4. use Firebase only when PT-Portal returns `404`
+5. preserve `410`, `429`, and `5xx` errors without falling through
+
+Recommended response for a PT package:
+
+```json
+{
+  "source": "pt_portal",
+  "token": "opaque-package-document-token"
+}
+```
+
+Recommended response for a legacy package:
+
+```json
+{
+  "source": "legacy_firebase",
+  "customer": {}
+}
+```
+
+The existing `/api/lookup-customer` can remain unchanged for legacy fallback, but `ClientPortal.jsx` should call `/api/package-access` instead.
+
+### 7.2 New `api/package-data.js`
+
+This function should accept the PT package token, request the current package data from PT-Portal, and return the public response to the browser.
+
+It must:
+
+- accept `GET` only
+- validate token length and allowed characters
+- URL-encode the token when forwarding
+- set `Cache-Control: private, no-store`
+- preserve `404` and `410` semantics
+- use a request timeout
+- return JSON even when the upstream returns HTML or an empty response
+- never log the token
+
+### 7.3 Session Handling
+
+Phase 1 may keep the token in React state and in the `/package-documents/:token` route because existing access vouchers already use that URL.
+
+The preferred hardened flow is:
+
+1. `/api/package-access` receives a valid PT token from PT-Portal
+2. bookings portal stores it in an encrypted, `HttpOnly`, `Secure`, `SameSite=Lax` cookie
+3. `/api/package-data` reads the cookie server-side
+4. the normal post-login page uses `/documents` without exposing a fresh token in client state
+
+The direct `/package-documents/:token` route must remain supported for QR compatibility, but it can immediately exchange the token for the secure session cookie and replace the URL using React Router navigation.
+
+---
+
+## 8. Source Routing Rules
+
+Source selection must be deterministic.
+
+```text
+Reference/surname submitted
+-> Ask PT-Portal
+   -> 200: open PT package
+   -> 404: ask legacy Firebase
+   -> 410: show expired; stop
+   -> 429: show throttled; stop
+   -> 500/timeout: show service unavailable; stop
+```
+
+Do not fall back to Firebase on every PT-Portal error. A broad fallback could reopen an expired package or show stale legacy data for a package now controlled by PT-Portal.
+
+If both systems contain the same reference, PT-Portal wins.
+
+The portal should retain the resolved source for the duration of the session:
+
+```text
+pt_portal
+legacy_firebase
+```
+
+Do not mix documents from both sources on one customer screen.
+
+---
+
+## 9. Customer Data Mapping
+
+The existing `ClientDashboard` expects a legacy Firestore customer object. Do not force PT-Portal data into that shape throughout the UI. Introduce a normalized portal view model.
+
+Suggested model:
+
+```typescript
+type PortalPackage = {
+  source: 'pt_portal' | 'legacy_firebase'
+  reference: string
+  customerName: string
+  packageType: string
+  destination: string
+  departureDate: string | null
+  returnDate: string | null
+  accessExpiresAt: string | null
+  statusLabel: string
+  publicSummary: Record<string, unknown>
+  documents: PortalDocument[]
+  transportVoucher: PortalTransportVoucher | null
+  releasedInvoice: PortalInvoice | null
+  checklist: PortalChecklistItem[]
+  keyInformation: PortalKeyInformation
+}
+```
+
+Suggested document category mapping:
+
+| PT-Portal | Customer label | Legacy category |
+|---|---|---|
+| `flight` | Flights | Flights |
+| `hotel` | Hotels | Hotels |
+| `transport` | Transport | Transport |
+| `visa` | Visa | Visa |
+| `e_sim` | E-Sim | E-Sim |
+| `insurance` | Insurance | Insurance |
+| `invoice` | Invoice | No direct legacy equivalent |
+| `other` | Other | Others |
+
+`travel_documents` is agent-only in the normal customer portal and must not be displayed even if malformed upstream data contains it.
+
+Invoice data must be displayed only from `releasedInvoice`. Never infer invoice visibility from a document name or package status.
+
+Transport voucher data must be displayed only when the API returns the latest `released_to_customer` voucher.
+
+---
+
+## 10. Customer Portal Interface
+
+### 10.1 Login
+
+Keep the familiar reference and surname login, but improve the following:
+
+- accept full or partial PT reference input
+- keep field labels visible on mobile
+- use `autocomplete="family-name"` for surname
+- show a neutral error for invalid details
+- distinguish expired access from invalid details
+- show a retry timer/message after `429`
+- remove agent or IMS installation prompts from all customer routes
+
+### 10.2 Package Header
+
+Show:
+
+- Piyam Travel logo
+- package reference
+- lead customer name
+- package type and destination
+- departure and return dates
+- access expiry
+- logout button
+
+### 10.3 Main Navigation
+
+Recommended mobile-first sections:
+
+```text
+Overview
+Documents
+Transport
+Invoice (only when released)
+```
+
+Do not render an empty Invoice or Transport tab.
+
+On mobile, use a compact sticky tab row or segmented navigation. Avoid a wide desktop grid compressed into the phone viewport.
+
+### 10.4 Documents
+
+Group documents by category. Hide empty categories.
+
+Each document should show:
+
+- customer-facing title
+- category
+- file size
+- release date
+- public note, when present
+- Preview action
+- Download action
+
+Preview behaviour:
+
+| File type | Behaviour |
+|---|---|
+| PDF | Open responsive modal/iframe using `preview_url` |
+| JPG/JPEG/PNG/WebP | Contained image preview |
+| HTML transport voucher | Open `preview_url` in a new tab with print support |
+| Unknown/office file | Download only |
+
+If a signed link expires while the page remains open, reload package data and retry once.
+
+### 10.5 Transport Voucher
+
+Show a concise structured summary from `transportVoucher.voucher_data`:
+
+- arrival/departure details
+- route timeline
+- vehicle type per route
+- transport provider contact when released
+- driver contact when released
+- public notes
+- voucher version and release date
+
+Do not show internal supplier allocation fields or route net costs.
+
+When a released transport document is available, include a clear **View / Print voucher** action. HTML vouchers should open online rather than download as raw source.
+
+### 10.6 Released Invoice
+
+Show only the immutable customer snapshot returned as `releasedInvoice`:
+
+- invoice number and version
+- customer-visible line descriptions
+- quantity and sold amount
+- discount
+- total
+- amount paid
+- balance due
+- due date
+- customer terms
+
+Never show:
+
+- booked supplier cost
+- projected margin/profit
+- expected or received commission
+- internal notes
+- hidden invoice lines
+- draft invoice changes not released by an agent
+
+---
+
+## 11. Customer Updates and Checklist
+
+The legacy portal currently lets customers update local SIM/email and toggle checklist items directly in Firestore.
+
+For PT-Portal packages, these controls must not write to Firebase.
+
+Phase 1 recommendation:
+
+- render PT package checklist as read-only status
+- show customer email as read-only
+- direct changes to the agent through WhatsApp
+- do not add customer-write APIs until the exact audit and validation rules are agreed
+
+Future customer-write endpoints should live in PT-Portal and record audit events. They should not update Supabase directly from the bookings portal browser.
+
+Legacy Firebase customers may retain their existing editable controls until migration.
+
+---
+
+## 12. Environment Variables
+
+Add to the bookings portal Vercel project:
+
+```text
+PT_PORTAL_BASE_URL=https://<pt-portal-production-domain>
+PT_PORTAL_REQUEST_TIMEOUT_MS=10000
+PACKAGE_PORTAL_SESSION_SECRET=<long-random-server-only-secret>
+```
+
+Optional future hardening:
+
+```text
+PT_PORTAL_INTEGRATION_SECRET=<shared-server-only-secret>
+```
+
+Rules:
+
+- do not use a `VITE_` prefix for secrets
+- do not add Supabase service keys to the bookings portal
+- do not add MinIO keys to the browser
+- retain Firebase and R2 variables only while legacy access remains active
+- configure the PT-Portal production base URL rather than hardcoding it
+
+PT-Portal should retain:
+
+```text
+NEXT_PUBLIC_BOOKINGS_PORTAL_URL=https://bookings.piyamtravel.com
+```
+
+This ensures generated access links and transport voucher QR codes point to the customer portal.
+
+---
+
+## 13. Security Requirements
+
+### 13.1 Authentication and Access
+
+- Treat the document token as a password-equivalent secret.
+- Never put tokens, surnames, document URLs, or customer data in application logs.
+- Do not store the token in localStorage.
+- Clear package state and session cookie on logout.
+- Use generic invalid-login wording to avoid package enumeration.
+- Preserve PT-Portal `429` rate limits.
+- Reject expired or revoked access immediately.
+
+### 13.2 Document Security
+
+- Use only signed URLs returned by PT-Portal.
+- Do not convert MinIO objects into public bucket URLs.
+- Do not cache package API responses in shared caches.
+- Set `Referrer-Policy: no-referrer` on token routes and document previews where practical.
+- Open external document tabs with `noopener,noreferrer`.
+- Sandbox HTML previews unless the HTML is opened through the controlled PT-Portal voucher endpoint.
+- Do not expose internal document metadata, storage bucket names, or object keys in customer components.
+
+### 13.3 Data Minimisation
+
+The customer portal should receive only data needed for the customer experience.
+
+Never expose:
+
+- internal notes
+- supplier booked costs
+- employee IDs
+- reservation internal notes
+- commissions
+- audit events
+- package risk flags
+- third-party share access codes
+- other family/package personal data
+
+### 13.4 API Hardening Follow-Up
+
+PT-Portal's current public access endpoints are sufficient for initial integration. A later hardening phase should add signed server-to-server requests between the two portals while keeping customer authentication unchanged.
+
+---
+
+## 14. Error Handling
+
+Customer-facing errors should be clear and calm.
+
+| Situation | Customer message |
+|---|---|
+| Wrong reference/surname | Package details do not match. Check the lead passenger surname and reference. |
+| Access disabled/revoked | Package documents are not currently available. Contact your agent. |
+| Access expired | Your document access has expired. Contact your agent to renew access. |
+| Too many attempts | Too many attempts. Please wait before trying again. |
+| PT-Portal timeout | The package service is temporarily unavailable. Please try again shortly. |
+| No released documents | Your package is open, but no documents have been released yet. |
+| Signed URL expired | Refreshing your secure document link. |
+
+Do not convert upstream `500` errors into "invalid reference" messages.
+
+The bookings portal serverless functions must always return JSON error envelopes, even when PT-Portal returns an HTML error page.
+
+---
+
+## 15. Recommended File Changes in Bookings Portal
+
+```text
+api/
+  package-access.js              New PT-first access resolver
+  package-data.js                New PT package proxy
+  lookup-customer.js             Keep as legacy-only lookup
+
+src/
+  App.jsx                        Add /package-documents/:token route
+  components/
+    ClientPortal.jsx             Resolve source and use normalized view model
+    portal/
+      PackageLogin.jsx           Shared login form
+      PackagePortal.jsx          PT package customer shell
+      PackageHeader.jsx
+      PackageOverview.jsx
+      PackageDocuments.jsx
+      PackageDocumentPreview.jsx
+      PackageTransportVoucher.jsx
+      PackageInvoice.jsx
+      PackageErrorState.jsx
+  services/
+    packagePortalApi.js          Browser calls to same-origin serverless APIs
+  adapters/
+    ptPortalPackageAdapter.js    PT response -> normalized view model
+    legacyPackageAdapter.js      Firestore response -> normalized view model
+  types/
+    packagePortal.js             JSDoc or TypeScript contracts
+```
+
+`ClientPortal.jsx` is currently a large component containing login, dashboard, preview, checklist, and customer updates. Split it during this integration so PT and legacy behaviour do not become a chain of source-specific conditionals.
+
+---
+
+## 16. Implementation Phases
+
+### Phase 1: Read-Only PT Package Support
+
+- add `PT_PORTAL_BASE_URL`
+- add `/api/package-access`
+- add `/api/package-data`
+- add `/package-documents/:token`
+- normalize PT package response
+- render released documents
+- support inline preview and download
+- preserve legacy Firebase login fallback
+- add source-specific error handling
+
+Exit condition:
+
+```text
+A newly converted and released PT-Portal package can be opened on
+bookings.piyamtravel.com by reference/surname and by QR token.
+```
+
+### Phase 2: Released Voucher and Invoice Experience
+
+- add structured transport voucher view
+- add View / Print for released HTML/PDF voucher
+- add released invoice view
+- refresh expired signed URLs automatically
+- improve mobile tabs and document preview
+
+### Phase 3: Session and Security Hardening
+
+- exchange URL token for secure cookie
+- remove token from visible route after exchange where possible
+- add bookings portal rate limits
+- add service-to-service request signing
+- add request IDs without customer data
+- add security headers and no-store controls
+
+### Phase 4: Legacy Migration Cutover
+
+- compare migrated Firebase records with PT-Portal package folders
+- mark migrated legacy records read-only
+- disable legacy folder creation
+- retain lookup fallback during a monitored grace period
+- remove Firebase customer lookup only after access parity is confirmed
+- remove R2 legacy document dependencies after retention requirements are met
+
+---
+
+## 17. Test Matrix
+
+### Authentication
+
+- full `PT-XXXXXX` reference works
+- six-character reference without prefix works
+- lowercase reference works
+- surname normalization works for spaces, apostrophes, and hyphens
+- wrong surname returns neutral error
+- expired PT package returns `410` and does not open Firebase record
+- revoked PT package does not open
+- repeated failed attempts produce `429`
+- legacy Firebase package still opens after PT `404`
+- PT `500` does not fall back to stale Firebase data
+
+### Direct Links
+
+- `/package-documents/:token` opens from a copied access voucher link
+- transport voucher QR opens the same package
+- invalid token shows a controlled error
+- expired token shows renewal guidance
+- page refresh on token route still works through Vercel rewrite
+
+### Documents
+
+- only released/customer-visible documents appear
+- revoked documents disappear on refresh
+- new releases appear on refresh
+- empty categories stay hidden
+- PDF preview fits desktop and mobile modal
+- image preview uses contained sizing
+- HTML transport voucher opens online and prints
+- download uses the filename supplied by PT-Portal
+- expired signed URL refreshes once
+- `travel_documents` never appears in normal customer view
+
+### Invoice
+
+- draft invoice is hidden
+- released invoice appears
+- amended but unreleased invoice does not replace the released snapshot
+- only customer-visible lines appear
+- booked cost, margin, and commission are absent
+
+### Mobile
+
+- no horizontal page overflow at 320px width
+- tabs remain usable with one hand
+- document actions do not overlap filenames
+- preview can be closed without browser back navigation
+- price/invoice tables collapse into readable rows
+- no IMS install prompt appears
+
+### Security
+
+- no Supabase or MinIO secret exists in client bundle
+- package token is absent from logs
+- package responses use `private, no-store`
+- logout clears customer data
+- one customer cannot switch references by changing client state alone
+
+---
+
+## 18. Acceptance Criteria
+
+The integration is complete when all of the following are true:
+
+- a package created and converted in PT-Portal can open on `bookings.piyamtravel.com`
+- reference plus lead surname login works
+- PT-Portal access voucher links work
+- transport voucher QR links work
+- only released documents are visible
+- document previews and downloads work using temporary signed URLs
+- released transport voucher details display correctly
+- released invoices display without internal financial data
+- expired and revoked access is enforced
+- legacy Firebase customers continue to work during the transition
+- new packages are not duplicated into Firebase
+- the customer experience is responsive and clear on mobile
+- customer-facing routes do not show agent/IMS installation prompts
+
+---
+
+## 19. Decommission Conditions
+
+The legacy agent/customer data path should be removed only after:
+
+- all required Firebase customer folders have been migrated
+- migrated document counts match
+- migrated customers pass reference/surname login tests
+- access expiry values are preserved or intentionally reset
+- customer-visible document categories match
+- a rollback report exists for failed records
+- there has been a monitored period with no legacy-only customer access
+
+Until then, the bookings portal is a dual-source customer interface, with PT-Portal taking priority for every new package.
+
+---
+
+## 20. Remaining Release Tasks
+
+The implementation and automated verification are complete in this checkout. Finish the release in this order:
+
+1. review and commit the complete integration diff
+2. configure the documented server-only variables in Vercel Preview
+3. configure the matching PT-Portal preview bookings URL
+4. deploy the reviewed commit to Preview
+5. run the full smoke matrix with a real released PT package, a current QR link, and a known legacy Firebase package
+6. prove a revoked or disabled PT-owned package cannot fall through to a stale legacy record
+7. confirm PT-Portal rate limiting distinguishes customers correctly through the Vercel proxy
+8. approve Vercel log access, retention, and redaction for `/package-documents/:token`
+9. promote the approved configuration and commit to Production
+10. repeat the minimum production smoke tests and record the release outcome without customer credentials or tokens
+
+Use `docs/deployment-checklist.md` as the release record and rollback procedure.

--- a/Bookings portal integration.md
+++ b/Bookings portal integration.md
@@ -1,10 +1,10 @@
 # Bookings Portal Integration for PT-Portal Packages
 
-**Status:** Repository implementation complete; deployment and live acceptance pending
+**Status:** Preview deployed; live acceptance and production promotion pending
 
 **Created:** August 8, 2026
 
-**Implementation checkpoint:** August 8, 2026
+**Implementation checkpoint:** August 9, 2026
 
 **Customer Portal:** `https://bookings.piyamtravel.com`
 
@@ -16,7 +16,9 @@
 
 The repository now implements the Phase 1 and Phase 2 customer experience plus the secure cookie/session portion of Phase 3. Automated server, adapter, session, and client-contract tests pass together with the production build through `npm run check`.
 
-The remaining release gates require access outside this checkout: configure and deploy Vercel Preview/Production; validate a real released PT package, QR link, and legacy fallback; confirm revoked or disabled PT packages cannot reopen stale legacy data; confirm PT-Portal rate-limit identity when requests arrive through the bookings proxy; and approve Vercel edge-log handling for the initial token-bearing route. Track those checks in `docs/deployment-checklist.md`; repository build success alone does not complete the production release.
+Preview checkpoint: commit `9e93d13` is published in draft PR `#8`; both GitHub CI runs and the Vercel deployment check pass. The Vercel Preview has the PT endpoint, request timeout, and a Preview-specific package-session secret configured. Credential-free smoke tests passed for `/`, `/documents`, `/package-documents/:token`, controlled package API errors, live PT package-data connectivity, PT-first reference access, legacy not-found handling, and session logout/security headers.
+
+The remaining release gates require authorized live data or production coordination: validate a real released PT package, QR link, and legacy fallback; confirm revoked or disabled PT packages cannot reopen stale legacy data; confirm PT-Portal rate-limit identity when requests arrive through the bookings proxy; approve Vercel edge-log handling for the initial token-bearing route; set PT-Portal's `NEXT_PUBLIC_BOOKINGS_PORTAL_URL` during the coordinated production promotion; and complete production smoke testing. Track those checks in `docs/deployment-checklist.md`; repository and Preview success alone do not complete the production release.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,111 +1,133 @@
-# Piyam Travel Portal
+# Piyam Travel Bookings Portal
 
-A secure, web-based portal for Piyam Travel agents to manage customer travel packages and for customers to securely access their documents.
+The customer-facing portal at bookings.piyamtravel.com provides access to travel-package documents while the business moves from legacy Firebase folders to PT-Portal packages.
 
-This project consists of two main parts: a secure **Agent Dashboard** for managing client data and a simple **Client Portal** for viewing and downloading documents.
+New packages are owned and managed in PT-Portal. This repository remains responsible for the customer interface, same-origin serverless adapters, and temporary read access to legacy Firebase and Cloudflare R2 records. The <code>/agent</code> route is a legacy migration tool and must not become a second source of truth for new PT packages.
 
----
+## Application routes
 
-## Features
+- <code>/</code> accepts a package reference and lead passenger surname.
+- <code>/package-documents/:token</code> supports PT-Portal access vouchers and transport-voucher QR codes.
+- <code>/documents</code> is the token-free URL used after a secure package session is established.
+- <code>/agent</code> provides the temporary Firebase agent dashboard for legacy folders.
 
-#### Agent Dashboard
-- Create unique, reference-numbered folders for each customer.
-- Search and filter customer folders by name or reference number.
-- Upload and manage documents (`.pdf`, `.jpg`) across multiple categories (Flights, Hotels, Visa, etc.).
-- Delete documents from a customer's folder.
-- Generate a shareable Access Voucher with a QR code for easy client access.
+The browser calls only same-origin <code>/api</code> endpoints. Serverless functions contact PT-Portal, Firebase Admin, Cloudflare R2, and Mailgun with server-only credentials.
 
-#### Client Portal
-- Secure login using a unique Reference Number and the customer's Last Name.
-- A clean, read-only dashboard displaying all relevant travel documents.
-- Categories are dynamically hidden if they contain no documents.
-- "Download" button for each file.
-- An automated 10-month access expiry notification for security.
+## Requirements
 
----
+- Node.js 20 or newer
+- npm
+- Git
+- Vercel CLI or a linked Vercel project when testing serverless functions locally
+- Access to the required development or preview credentials
 
-## Technology Stack
+Current dependency resolutions include packages that require Node 20. Do not use Node 18 for installation, local verification, or deployment.
 
-This project is built with a modern, serverless architecture to keep costs at a minimum while ensuring high performance and security.
+## Local setup
 
-- **Frontend:** React, Vite, Tailwind CSS
-- **Database:** Google Firestore
-- **File Storage:** Cloudflare R2 (10GB Free Tier)
-- **Hosting & Backend Functions:** Vercel
-- **Authentication:** Google Firebase Authentication
+1. Clone and enter the repository.
 
----
+       git clone https://github.com/Piyam-Travel-LTD/piyam-travel-bookings-portal.git
+       cd piyam-travel-bookings-portal
 
-## Setup and Installation
+2. Install dependencies.
 
-Follow these steps to get the project running on your local machine for development and testing.
+       npm install
 
-### Prerequisites
+3. Create a local environment file and replace every required placeholder.
 
-- [Node.js](https://nodejs.org/) (version 18.x or higher)
-- [Git](https://git-scm.com/)
-- A code editor like [Visual Studio Code](https://code.visualstudio.com/)
+       cp .env.example .env.local
 
-### 1. Clone the Repository
+4. Generate a unique session secret of at least 32 random characters. For example:
 
-First, clone the code from your GitHub repository to your local machine.
-```
-git clone [https://github.com/YOUR_USERNAME/piyam-travel-portal.git](https://github.com/YOUR_USERNAME/piyam-travel-portal.git)
-cd piyam-travel-portal
-```
+       openssl rand -base64 48
 
-### 2. Install Dependencies
-Install all the necessary project libraries using npm.
-```
-npm install
-```
+   Put the result in <code>PACKAGE_PORTAL_SESSION_SECRET</code>. Never reuse production secrets in local or preview environments.
 
-### 3. Set Up Environment Variables
+5. Run the frontend-only Vite server when API calls are not needed.
 
-For the application to connect to your backend services, you need to provide your secret keys in a local environment file.
+       npm run dev
 
-In the root of your `piyam-travel-portal folder`, create a new file named `.env`.
+6. Use Vercel development mode for end-to-end work involving <code>/api/package-access</code>, <code>/api/package-data</code>, or <code>/api/package-session</code>.
 
-Copy the content below into the `.env` file and replace the placeholder values with your actual credentials.
+       npx vercel dev
 
-**.env file contents:**
-```
-# Firebase Configuration
-VITE_FIREBASE_API_KEY="AIzaSyA..._w"
-VITE_FIREBASE_AUTH_DOMAIN="piyam-travel-portal.firebaseapp.com"
-VITE_FIREBASE_PROJECT_ID="piyam-travel-portal"
-VITE_FIREBASE_STORAGE_BUCKET="piyam-travel-portal.appspot.com"
-VITE_FIREBASE_MESSAGING_SENDER_ID="123456789012"
-VITE_FIREBASE_APP_ID="1:123456789012:web:abcdef1234567890"
+7. Run the automated contract tests and verify the production bundle before opening a pull request or deploying.
 
-# Cloudflare R2 Configuration (These are used by your Vercel functions)
-CLOUDFLARE_ACCOUNT_ID="YOUR_CLOUDFLARE_ACCOUNT_ID"
-R2_ACCESS_KEY_ID="YOUR_R2_ACCESS_KEY_ID"
-R2_SECRET_ACCESS_KEY="YOUR_R2_SECRET_ACCESS_KEY"
-R2_BUCKET_NAME="piyam-travel-documents"
-R2_PUBLIC_URL="YOUR_R2_PUBLIC_URL"
+       npm run check
 
-# Mailgun Configuration (For sending emails)
-MAILGUN_API_KEY="YOUR_MAILGUN_PRIVATE_API_KEY"
-MAILGUN_DOMAIN="YOUR_MAILGUN_DOMAIN" # e.g., mg.yourwebsite.com
-MAILGUN_SENDER_EMAIL="Piyam Travel <noreply@yourmaildomain.com>" # The 'From' address for emails
-```
-**Note:** The `VITE_` prefix is important. It tells Vite to make these variables securely available to your front-end code.
+Vite alone does not emulate the Vercel serverless functions. PT package login, direct-token routes, and legacy fallback require the full local Vercel runtime or a preview deployment.
 
-## Running the Application
-Once the setup is complete, you can start the local development server.
-```
-npm run dev
-```
-This will launch the application, and you can view it in your web browser at `http://localhost:5173` (or a similar address).
+## Environment configuration
+
+Use [.env.example](.env.example) as the inventory. Local <code>.env</code> variants are ignored by Git. Configure runtime values separately in Vercel for Preview and Production, then redeploy so the functions receive the updated values.
+
+### PT-Portal integration
+
+| Variable | Scope | Purpose |
+| --- | --- | --- |
+| <code>PT_PORTAL_BASE_URL</code> | Server-only, required | PT-Portal production or preview origin, without a trailing slash. Production must use HTTPS. |
+| <code>PT_PORTAL_REQUEST_TIMEOUT_MS</code> | Server-only | Upstream request timeout in milliseconds; defaults to 10000. |
+| <code>PACKAGE_PORTAL_SESSION_SECRET</code> | Server-only, required for hardened sessions | At least 32 random characters used to encrypt the <code>HttpOnly</code> package-session cookie. Without it, the portal falls back to keeping the token only in in-memory React state. |
+| <code>PT_PORTAL_INTEGRATION_SECRET</code> | Server-only, future optional | Shared request-signing secret. Leave unset until signing is implemented and coordinated in both repositories. |
+
+Do not add Supabase service-role keys, MinIO credentials, document tokens, or customer details to this project’s browser environment.
+
+### Legacy Firebase
+
+The following Firebase Admin variables are server secrets required by the legacy lookup, folder management, and purge functions:
+
+- <code>FIREBASE_PROJECT_ID</code>
+- <code>FIREBASE_CLIENT_EMAIL</code>
+- <code>FIREBASE_PRIVATE_KEY</code>, stored with literal <code>\n</code> line breaks as shown in the example
+
+The browser Firebase configuration currently lives in <code>src/firebase.js</code>. It is public client configuration and is not equivalent to a Firebase Admin credential. The example inventories the conventional <code>VITE_FIREBASE_*</code> names, but the current source does not read them; changing those environment values alone will not change the browser Firebase project.
+
+Any value prefixed with <code>VITE_</code> is embedded into the client bundle and can be read by portal visitors. Never place private keys, integration secrets, R2 credentials, Mailgun credentials, session secrets, or service-role keys in a <code>VITE_</code> variable.
+
+### Legacy Cloudflare R2
+
+The serverless upload, delete, voucher, and purge functions use:
+
+- <code>R2_ACCESS_KEY_ID</code>
+- <code>R2_SECRET_ACCESS_KEY</code>
+- <code>R2_BUCKET_NAME</code>
+- <code>R2_PUBLIC_URL</code>
+
+The current R2 endpoint is configured directly in the API modules, so <code>CLOUDFLARE_ACCOUNT_ID</code> is not consumed. Production <code>R2_PUBLIC_URL</code> must use HTTPS to prevent mixed-content failures.
+
+### Legacy Mailgun and purge automation
+
+- <code>MAILGUN_API_KEY</code>, <code>MAILGUN_DOMAIN</code>, and <code>MAILGUN_SENDER_EMAIL</code> support legacy completion email.
+- <code>CRON_SECRET</code> protects <code>/api/purge-old-folders</code>. The same value must exist as the GitHub Actions repository secret named <code>CRON_SECRET</code>.
+
+### Required PT-Portal setting
+
+In the PT-Portal deployment, configure:
+
+    NEXT_PUBLIC_BOOKINGS_PORTAL_URL=https://bookings.piyamtravel.com
+
+This value belongs to PT-Portal, not this repository. It controls generated customer links and transport-voucher QR codes.
+
+## Production security requirements
+
+- Both <code>https://bookings.piyamtravel.com</code> and <code>PT_PORTAL_BASE_URL</code> must have valid HTTPS certificates.
+- All customer document URLs must use HTTPS. Do not deploy a production configuration that produces mixed content.
+- Keep every server credential out of <code>VITE_*</code> variables and Git history.
+- Use separate random secrets for local, Preview, and Production.
+- Treat package-document tokens as password-equivalent. Do not copy them into issue trackers, analytics, screenshots, or logs.
+- Verify that the proxy preserves the intended client-IP/rate-limit semantics without trusting a browser-supplied forwarding header.
+- Secure cookies require HTTPS in Preview and Production. Local HTTP testing does not prove production cookie behavior.
 
 ## Deployment
-This project is configured for easy deployment on Vercel.
 
-- Push your code to your GitHub repository.
+Follow the [deployment and smoke-test checklist](docs/deployment-checklist.md). A preview deployment must pass the source-routing, token-link, document, mobile, and security checks before production promotion.
 
-- Follow the steps we previously discussed to import and configure the project in your Vercel dashboard.
+Four release gates require external access and cannot be completed from this checkout alone:
 
-- Ensure you have added the same Environment Variables from your .env file into your Vercel project settings.
+1. Vercel Preview and Production environment variables must be configured and a deployment created.
+2. An authorized operator must validate a real released PT package by reference/surname and through its real access-voucher or transport-voucher QR link.
+3. PT-Portal ownership must confirm revoked/disabled-package fallback semantics and customer-specific rate limiting through the Vercel proxy.
+4. The Vercel owner must approve access, retention, and redaction controls for the initial token-bearing route in edge request logs.
 
-- Vercel will automatically build and deploy your application every time you push a new change to your GitHub repository.
+Do not mark the integration complete until both gates are recorded.

--- a/api/lookup-customer.js
+++ b/api/lookup-customer.js
@@ -1,62 +1,38 @@
-import admin from 'firebase-admin';
+import {
+  HttpError,
+  parseJsonBody,
+  rejectMethod,
+  sendError,
+  setPrivateJsonHeaders
+} from '../server/http.js';
+import { resolvePackageAccess } from '../server/package-access-resolver.js';
 
-// This securely initializes the Firebase Admin SDK using the credentials
-// you stored in Vercel's Environment Variables.
-try {
-  if (!admin.apps.length) {
-    admin.initializeApp({
-      credential: admin.credential.cert({
-        projectId: process.env.FIREBASE_PROJECT_ID,
-        clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-        privateKey: process.env.FIREBASE_PRIVATE_KEY.replace(/\\n/g, '\n'),
-      })
-    });
-  }
-} catch (error) {
-  console.error('Firebase admin initialization error', error.stack);
-}
+export function createLegacyLookupHandler({ resolver = resolvePackageAccess } = {}) {
+  return async function handler(req, res) {
+    setPrivateJsonHeaders(res);
+    if (req.method !== 'POST') return rejectMethod(res, 'POST');
 
-const db = admin.firestore();
+    try {
+      const body = parseJsonBody(req);
+      const reference = body.referenceNumber ?? body.reference ?? body.referenceNumberInput;
+      const lastName = body.lastName ?? body.surname;
+      const result = await resolver(reference, lastName);
 
-export default async function handler(req, res) {
-  if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method Not Allowed' });
-  }
+      if (result.source === 'pt_portal') {
+        throw new HttpError(
+          410,
+          'This package is managed in the current package portal. Refresh the page and sign in again.',
+          { code: 'LEGACY_ENDPOINT_RETIRED' }
+        );
+      }
 
-  const { referenceNumber, lastName } = req.body;
-
-  if (!referenceNumber || !lastName) {
-    return res.status(400).json({ error: 'Reference number and last name are required.' });
-  }
-
-  try {
-    const customersRef = db.collection('customers');
-    const q = customersRef
-      .where('referenceNumber', '==', `PT-${referenceNumber.trim().toUpperCase()}`)
-      .where('lastName_lowercase', '==', lastName.trim().toLowerCase());
-      
-    const querySnapshot = await q.get();
-
-    if (querySnapshot.empty) {
-      return res.status(404).json({ error: 'Invalid reference number or last name. Please try again.' });
+      // Preserve the legacy endpoint's raw customer response shape for old clients,
+      // but only after PT-Portal has returned a genuine 404.
+      return res.status(200).json(result.customer);
+    } catch (error) {
+      return sendError(res, error);
     }
-
-    const doc = querySnapshot.docs[0];
-    const customerData = doc.data();
-
-    // This is the crucial fix for the date translation
-    const finalData = {
-      ...customerData,
-      id: doc.id,
-      createdAt: customerData.createdAt ? customerData.createdAt.toDate().toISOString() : null,
-      lastUpdatedAt: customerData.lastUpdatedAt ? customerData.lastUpdatedAt.toDate().toISOString() : null,
-      accessExpiresAt: customerData.accessExpiresAt ? customerData.accessExpiresAt.toDate().toISOString() : null,
-    };
-    
-    return res.status(200).json(finalData);
-
-  } catch (error) {
-    console.error('API Lookup Error:', error);
-    return res.status(500).json({ error: 'An internal server error occurred.' });
-  }
+  };
 }
+
+export default createLegacyLookupHandler();

--- a/api/package-access.js
+++ b/api/package-access.js
@@ -1,0 +1,48 @@
+import {
+  parseJsonBody,
+  rejectMethod,
+  sendError,
+  setPrivateJsonHeaders
+} from '../server/http.js';
+import { resolvePackageAccess } from '../server/package-access-resolver.js';
+import {
+  clearPackageSessionCookie,
+  setPackageSessionCookie
+} from '../server/package-session.js';
+
+export function createPackageAccessHandler({
+  resolver = resolvePackageAccess,
+  env = process.env
+} = {}) {
+  return async function handler(req, res) {
+    setPrivateJsonHeaders(res);
+    if (req.method !== 'POST') return rejectMethod(res, 'POST');
+
+    try {
+      const body = parseJsonBody(req);
+      const reference = body.reference ?? body.referenceNumber ?? body.referenceNumberInput;
+      const lastName = body.lastName ?? body.surname;
+      const result = await resolver(reference, lastName);
+
+      if (result.source === 'pt_portal') {
+        const sessionEstablished = setPackageSessionCookie(res, result.token, { env });
+        const response = {
+          source: 'pt_portal',
+          sessionEstablished
+        };
+        if (!sessionEstablished) response.token = result.token;
+        return res.status(200).json(response);
+      }
+
+      clearPackageSessionCookie(res);
+      return res.status(200).json({
+        source: 'legacy_firebase',
+        customer: result.customer
+      });
+    } catch (error) {
+      return sendError(res, error);
+    }
+  };
+}
+
+export default createPackageAccessHandler();

--- a/api/package-data.js
+++ b/api/package-data.js
@@ -1,0 +1,86 @@
+import {
+  getSingleQueryValue,
+  HttpError,
+  readBearerToken,
+  rejectMethod,
+  sendError,
+  setPrivateJsonHeaders
+} from '../server/http.js';
+import {
+  createPackagePortalClient,
+  requirePackageToken
+} from '../server/package-portal.js';
+import {
+  clearPackageSessionCookie,
+  PACKAGE_SESSION_COOKIE,
+  parseCookies,
+  readPackageSession,
+  setPackageSessionCookie
+} from '../server/package-session.js';
+
+function resolveRequestToken(req, env) {
+  const bearerValue = readBearerToken(req);
+  const queryValue = getSingleQueryValue(
+    req.query?.token ?? req.query?.reference ?? req.params?.token
+  );
+  const bearerToken = bearerValue == null ? null : requirePackageToken(bearerValue);
+  const queryToken = queryValue == null || queryValue === ''
+    ? null
+    : requirePackageToken(queryValue);
+
+  if (bearerToken && queryToken && bearerToken !== queryToken) {
+    throw new HttpError(400, 'Conflicting package access tokens were supplied.', {
+      code: 'CONFLICTING_TOKENS'
+    });
+  }
+  if (bearerToken) return { token: bearerToken, source: 'bearer' };
+  if (queryToken) return { token: queryToken, source: 'query' };
+
+  const session = readPackageSession(req, { env });
+  if (session) return { token: session.token, source: 'cookie' };
+  const cookies = parseCookies(req?.headers?.cookie);
+  throw new HttpError(400, 'Invalid package access token.', {
+    code: cookies[PACKAGE_SESSION_COOKIE] ? 'INVALID_SESSION' : 'MISSING_TOKEN'
+  });
+}
+
+export function createPackageDataHandler({
+  portalClientFactory = () => createPackagePortalClient(),
+  env = process.env
+} = {}) {
+  return async function handler(req, res) {
+    setPrivateJsonHeaders(res);
+    if (req.method !== 'GET') return rejectMethod(res, 'GET');
+
+    let tokenSource = null;
+    try {
+      const resolved = resolveRequestToken(req, env);
+      tokenSource = resolved.source;
+      if (tokenSource === 'query') {
+        res.setHeader('Deprecation', 'true');
+      }
+
+      const packageData = await portalClientFactory().loadPackage(resolved.token);
+      let sessionEstablished = tokenSource === 'cookie';
+      if (tokenSource === 'bearer') {
+        sessionEstablished = setPackageSessionCookie(res, resolved.token, { env });
+      }
+
+      return res.status(200).json({
+        ...packageData,
+        sessionEstablished
+      });
+    } catch (error) {
+      if (
+        (tokenSource === 'cookie' && [400, 404, 410].includes(error?.status)) ||
+        error?.code === 'INVALID_SESSION'
+      ) {
+        clearPackageSessionCookie(res);
+      }
+      return sendError(res, error);
+    }
+  };
+}
+
+export { resolveRequestToken };
+export default createPackageDataHandler();

--- a/api/package-session.js
+++ b/api/package-session.js
@@ -1,0 +1,53 @@
+import {
+  HttpError,
+  readBearerToken,
+  rejectMethod,
+  sendError,
+  setPrivateJsonHeaders
+} from '../server/http.js';
+import {
+  createPackagePortalClient,
+  requirePackageToken
+} from '../server/package-portal.js';
+import {
+  clearPackageSessionCookie,
+  isPackageSessionConfigured,
+  setPackageSessionCookie
+} from '../server/package-session.js';
+
+export function createPackageSessionHandler({
+  portalClientFactory = () => createPackagePortalClient(),
+  env = process.env
+} = {}) {
+  return async function handler(req, res) {
+    setPrivateJsonHeaders(res);
+    if (!['POST', 'DELETE'].includes(req.method)) {
+      return rejectMethod(res, ['POST', 'DELETE']);
+    }
+
+    if (req.method === 'DELETE') {
+      clearPackageSessionCookie(res);
+      return res.status(200).json({ sessionEstablished: false });
+    }
+
+    try {
+      if (!isPackageSessionConfigured(env)) {
+        throw new HttpError(503, 'Secure package sessions are not configured.', {
+          code: 'SESSION_NOT_CONFIGURED'
+        });
+      }
+
+      const token = requirePackageToken(readBearerToken(req));
+      const packageData = await portalClientFactory().loadPackage(token);
+      setPackageSessionCookie(res, token, { env });
+      return res.status(200).json({
+        ...packageData,
+        sessionEstablished: true
+      });
+    } catch (error) {
+      return sendError(res, error);
+    }
+  };
+}
+
+export default createPackageSessionHandler();

--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -1,0 +1,118 @@
+# Bookings Portal Deployment Checklist
+
+Use this checklist for both the initial PT-Portal integration and later releases that affect customer access. Do not paste customer surnames, access tokens, signed document URLs, or private environment values into this document, pull requests, or issue trackers.
+
+## 1. Prepare the release
+
+- [ ] Confirm the intended commit and review the complete diff.
+- [ ] Install and build with Node.js 20 or newer.
+- [ ] Run the project’s available automated checks and record the results.
+- [ ] Confirm that no Supabase service-role key, MinIO key, Firebase Admin key, R2 key, Mailgun key, document token, or session secret is present in the client bundle or Git diff.
+- [ ] Confirm <code>.env</code> files remain untracked and only placeholder values exist in <code>.env.example</code>.
+- [ ] Record the currently promoted Vercel production deployment so it can be restored quickly.
+- [ ] Identify an authorized test PT package with at least one released document, a valid lead surname, and a current voucher or QR link.
+- [ ] Identify a legacy Firebase package that may be used for fallback verification.
+
+## 2. Configure Vercel Preview
+
+Configure these values in the Preview environment and redeploy after changing them:
+
+- [ ] <code>PT_PORTAL_BASE_URL</code> points to the intended HTTPS PT-Portal environment and has no trailing slash.
+- [ ] <code>PT_PORTAL_REQUEST_TIMEOUT_MS</code> is set to the approved value, normally <code>10000</code>.
+- [ ] <code>PACKAGE_PORTAL_SESSION_SECRET</code> contains at least 32 random characters and differs from Production.
+- [ ] <code>PT_PORTAL_INTEGRATION_SECRET</code> is absent unless request signing is active in both portals.
+- [ ] Firebase Admin variables are present while legacy fallback remains supported.
+- [ ] R2 variables are present while legacy documents remain supported.
+- [ ] Mailgun variables are present if completion emails are in release scope.
+- [ ] <code>CRON_SECRET</code> matches the GitHub Actions repository secret if the preview environment is intended to exercise purge automation.
+- [ ] No server secret uses a <code>VITE_</code> prefix.
+- [ ] Preview and PT-Portal origins use valid HTTPS certificates.
+
+On the corresponding PT-Portal deployment:
+
+- [ ] Set <code>NEXT_PUBLIC_BOOKINGS_PORTAL_URL</code> to the intended bookings portal URL.
+- [ ] Regenerate or obtain a new test access link after changing that value.
+- [ ] Confirm generated transport-voucher QR codes use the same URL.
+
+Production PT-Portal must use:
+
+    NEXT_PUBLIC_BOOKINGS_PORTAL_URL=https://bookings.piyamtravel.com
+
+## 3. Preview smoke-test matrix
+
+Record pass/fail and the sanitized evidence location for each row.
+
+| Area | Required check |
+| --- | --- |
+| Reference normalization | The same PT package opens with the six-character code, full <code>PT-XXXXXX</code> reference, and lowercase reference. An overlong or malformed reference is rejected rather than truncated to another package. |
+| Surname handling | Leading/trailing spaces are normalized and valid surnames containing spaces, apostrophes, or hyphens work. A wrong surname receives neutral wording. |
+| PT priority | A valid PT package opens from PT-Portal. If both sources contain the reference, PT-Portal wins. |
+| Fallback boundary | Legacy Firebase is queried only after a genuine PT <code>404</code>. Confirm <code>410</code>, <code>429</code>, timeout, and <code>5xx</code> never open a legacy record. |
+| Revoked ownership | A disabled or revoked PT-owned package cannot return the fallback-triggering not-found result and reopen a stale Firebase record with the same reference. |
+| Legacy access | A known legacy package opens after PT returns <code>404</code>; its header, documents, preview/download controls, checklist, and permitted legacy updates still work. |
+| Direct token | A copied <code>/package-documents/:token</code> link opens the same PT package after a hard refresh. Invalid, revoked, and expired tokens produce controlled guidance. |
+| QR link | Scan a real PT access-voucher or transport-voucher QR code on a phone and confirm it opens the expected package. |
+| Released documents | Only customer-visible released documents appear. Empty categories and <code>travel_documents</code> remain hidden. |
+| Preview/download | Test PDF, image, HTML voucher, and download-only file behavior. Confirm the supplied filename and new-tab protections. |
+| Signed URL expiry | Leave the portal open until a signed URL expires; the portal refreshes package data and retries only once. |
+| Transport | Only released, customer-safe transport fields appear; no supplier allocation or net cost is visible. View/Print works for the released voucher. |
+| Invoice | Only the released immutable snapshot appears. Hidden lines, booked cost, margin, commission, draft changes, and internal notes are absent. |
+| Empty states | A package with no released documents shows the approved calm empty state and no empty Transport or Invoice tab. |
+| Logout | Logout clears customer state and any session cookie, replaces a token-bearing URL, and refresh does not reopen the package without valid access. |
+| Error semantics | Validate <code>400</code>, <code>404</code>, <code>410</code>, <code>429</code>, timeout, malformed upstream response, and <code>5xx</code>. Every API response is JSON and outages are not described as invalid details. |
+| Cache/referrer | Package-data responses are <code>private, no-store</code>. Token pages and previews do not send token-bearing referrers. |
+| Mobile | At 320 px width there is no horizontal overflow; tabs and document actions remain usable; previews close without browser Back. |
+| Customer routes | No agent-only or IMS installation prompt appears on customer routes. |
+
+## 4. Rate-limit and client-IP verification
+
+The customer browser calls the bookings portal, which then makes a server-to-server request to PT-Portal. PT-Portal must not accidentally treat all customers as the same Vercel egress client.
+
+- [ ] Coordinate with the PT-Portal owner to identify which trusted request field supplies the rate-limit identity.
+- [ ] Do not trust or blindly forward a browser-controlled <code>X-Forwarded-For</code> value.
+- [ ] If an originating address or pseudonymous identity is forwarded, derive it from Vercel-controlled request metadata and protect the integration with the agreed trust mechanism.
+- [ ] Make failed attempts from two independent clients and confirm one client’s limit does not unexpectedly throttle the other.
+- [ ] Confirm repeated failures from one client produce <code>429</code>.
+- [ ] Confirm the bookings proxy preserves the approved <code>Retry-After</code> value and the UI presents the expected wait guidance.
+- [ ] Inspect sanitized PT-Portal audit records to confirm successful access is attributed as designed.
+- [ ] Confirm neither portal logs the surname, package token, signed document URL, or customer response body.
+- [ ] Confirm Vercel access controls, retention, and redaction are acceptable for the unavoidable initial <code>/package-documents/:token</code> edge request.
+
+Do not release until the rate-limit identity is understood and the shared-egress risk has been ruled out or mitigated.
+
+## 5. Configure and release Production
+
+- [ ] Copy approved configuration into the Vercel Production scope; do not copy Preview secrets verbatim.
+- [ ] Confirm <code>PT_PORTAL_BASE_URL</code>, <code>R2_PUBLIC_URL</code>, and all customer-facing origins use HTTPS.
+- [ ] Confirm the PT-Portal production setting is exactly <code>NEXT_PUBLIC_BOOKINGS_PORTAL_URL=https://bookings.piyamtravel.com</code>.
+- [ ] Confirm DNS and TLS for <code>bookings.piyamtravel.com</code> are healthy.
+- [ ] Deploy the reviewed commit to Vercel Production.
+- [ ] Repeat the minimum production smoke tests: root login, a real PT package, its direct voucher/QR link, one released preview/download, controlled wrong login, controlled expired/revoked access, legacy fallback, logout, and a 320 px mobile check.
+- [ ] Check sanitized Vercel and PT-Portal logs for unexpected <code>5xx</code>, shared-client <code>429</code>, cache errors, or leaked sensitive query values.
+- [ ] Record operator, deployment identifier, commit, time, test package identifier in a protected operational system, and pass/fail outcome without recording credentials.
+
+The following are external release gates:
+
+- [ ] An authorized operator has configured and confirmed Vercel Preview and Production environment variables.
+- [ ] An authorized operator has tested a real released PT package by reference and surname.
+- [ ] An authorized operator has scanned a real current QR code and confirmed the package.
+- [ ] PT-Portal ownership has confirmed rate-limit/client-IP behavior and the production bookings URL.
+- [ ] PT-Portal ownership has confirmed disabled/revoked PT records cannot trigger stale legacy fallback.
+- [ ] Vercel edge-log access, retention, and redaction for token-bearing routes have been approved.
+
+Repository build success alone does not satisfy these gates.
+
+## 6. Rollback
+
+Rollback must restore availability without weakening source-routing security.
+
+1. Stop promotion and record the sanitized symptom, affected route, status code, and deployment identifier.
+2. Use Vercel to promote or redeploy the previously recorded known-good production deployment.
+3. Restore the last known-good Production environment configuration if configuration caused the incident. Handle values in Vercel; never write secrets into Git or incident notes.
+4. Keep PT-first routing semantics. Do not introduce broad Firebase fallback for <code>410</code>, <code>429</code>, timeouts, or <code>5xx</code> as an emergency workaround.
+5. Confirm the root customer page, a known legacy lookup, and the last known-good PT flow after rollback.
+6. Confirm PT-Portal still points generated production links to <code>https://bookings.piyamtravel.com</code>.
+7. Review sanitized logs and create a follow-up fix without copying tokens, surnames, signed URLs, or customer data.
+8. Re-run the Preview matrix before attempting production again.
+
+If the previous deployment cannot open current PT packages, treat that as an incident requiring coordination with the PT-Portal owner. Do not duplicate PT package data into Firebase.

--- a/index.html
+++ b/index.html
@@ -2,9 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/Logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Piyam Travel Portal</title>
+    <meta name="referrer" content="no-referrer" />
+    <title>Piyam Travel Bookings Portal</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,8799 @@
+{
+  "name": "piyam-travel-portal",
+  "version": "0.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "piyam-travel-portal",
+      "version": "0.0.0",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.598.0",
+        "@aws-sdk/s3-request-presigner": "^3.598.0",
+        "firebase": "^10.12.2",
+        "firebase-admin": "^12.1.1",
+        "mailgun.js": "^10.2.1",
+        "qrcode.react": "^3.1.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.24.0",
+        "zustand": "^4.5.2"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-react": "^4.2.1",
+        "autoprefixer": "^10.4.19",
+        "postcss": "^8.4.38",
+        "tailwindcss": "^3.4.4",
+        "vite": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.16.tgz",
+      "integrity": "sha512-EKnvkXSmz3IpA99tCNuI+dLFXyZyClSm8zns9sB/elvkU+MTuomAs6toJMPMBf98/fICG/urXDkzGz0/c3yyAQ==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1085.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1085.0.tgz",
+      "integrity": "sha512-O0xe8sR50AYkwxlvRRsV0qytEO2dtXQTQ1CF3YBBdE5xtVkbu27H0vGa1mjQi1/+fbYM80AWEIPai5jZmXyubw==",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.16",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-node": "^3.972.66",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.62",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.975.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
+      "integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.0",
+        "@aws-sdk/xml-builder": "^3.972.34",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
+      "integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
+      "integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
+      "integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-login": "^3.972.63",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
+      "integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.66.tgz",
+      "integrity": "sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-ini": "^3.973.1",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
+      "integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
+      "integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/token-providers": "3.1083.0",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
+      "integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.62",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.62.tgz",
+      "integrity": "sha512-k8JJwYXVYlOOjWnPZDThQS1xDFJgi5Dokt73qFlDtrZAbdcint5aIdjB9XgJAAQVP5OoqcefQmh1FYXiPpvsvw==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
+      "integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1085.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1085.0.tgz",
+      "integrity": "sha512-h8fv0zGAHPCjCpmAYdCeFE6trxXxLRxza0NRIajMZdnFgugtcIWcRAdAtc7rHvRTaXsej/I5YWXbq9SgKuCKow==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
+      "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1083.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
+      "integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
+      "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
+      "dependencies": {
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
+      "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
+      "dependencies": {
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA=="
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.8.tgz",
+      "integrity": "sha512-CVnHcS4iRJPqtIDc411+UmFldk0ShSK3OB+D0bKD8Ck5Vro6dbK5+APZpkuWpbfdL359DIQUnAaMLE+zs/PVyA==",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/installations": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.14.tgz",
+      "integrity": "sha512-unRVY6SvRqfNFIAA/kwl4vK+lvQAL2HVcgu9zTrUtTyYDmtIt/lOuHJynBMYEgLnKm39YKBDhtqdapP2e++ASw==",
+      "dependencies": {
+        "@firebase/analytics": "0.10.8",
+        "@firebase/analytics-types": "0.8.2",
+        "@firebase/component": "0.6.9",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.2.tgz",
+      "integrity": "sha512-EnzNNLh+9/sJsimsA/FGqzakmrAUKLeJvjRHlg8df1f97NLUlFidk9600y0ZgWOp3CAxn6Hjtk+08tixlUOWyw=="
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.10.13",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.10.13.tgz",
+      "integrity": "sha512-OZiDAEK/lDB6xy/XzYAyJJkaDqmQ+BCtOEPLqFvxWKUz5JbBmej7IiiRHdtiIOD/twW7O5AxVsfaaGA/V1bNsA==",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.8.8.tgz",
+      "integrity": "sha512-O49RGF1xj7k6BuhxGpHmqOW5hqBIAEbt2q6POW0lIywx7emYtzPDeQI+ryQpC4zbKX646SoVZ711TN1DBLNSOQ==",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.15.tgz",
+      "integrity": "sha512-zFIvIFFNqDXpOT2huorz9cwf56VT3oJYRFjSFYdSbGYEJYEaXjLJbfC79lx/zjx4Fh+yuN8pry3TtvwaevrGbg==",
+      "dependencies": {
+        "@firebase/app-check": "0.8.8",
+        "@firebase/app-check-types": "0.5.2",
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.2.tgz",
+      "integrity": "sha512-LMs47Vinv2HBMZi49C09dJxp0QT5LwDzFaVGf/+ITHe3BlIhUiLNttkATSXplc89A2lAaeTqjgqVkiRfUGyQiQ=="
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.2.tgz",
+      "integrity": "sha512-FSOEzTzL5bLUbD2co3Zut46iyPWML6xc4x+78TeaXMSuJap5QObfb+rVvZJtla3asN4RwU7elaQaduP+HFizDA=="
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.2.43",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.43.tgz",
+      "integrity": "sha512-HM96ZyIblXjAC7TzE8wIk2QhHlSvksYkQ4Ukh1GmEenzkucSNUmUX4QvoKrqeWsLEQ8hdcojABeCV8ybVyZmeg==",
+      "dependencies": {
+        "@firebase/app": "0.10.13",
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.2.tgz",
+      "integrity": "sha512-oMEZ1TDlBz479lmABwWsWjzHwheQKiAgnuKxE0pz0IXCVx7/rtlkx1fQ6GfgK24WCrxDKMplZrT50Kh04iMbXQ=="
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.14.tgz",
+      "integrity": "sha512-2eczCSqBl1KUPJacZlFpQayvpilg3dxXLy9cSMTKtQMTQSmondUtPI47P3ikH3bQAXhzKLOE+qVxJ3/IRtu9pw==",
+      "dependencies": {
+        "@firebase/auth": "1.7.9",
+        "@firebase/auth-types": "0.12.2",
+        "@firebase/component": "0.6.9",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0",
+        "undici": "6.19.7"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-compat/node_modules/@firebase/auth": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.7.9.tgz",
+      "integrity": "sha512-yLD5095kVgDw965jepMyUrIgDklD6qH/BZNHeKOgvu7pchOKNjVM+zQoOVYJIKWMWOWBq8IRNVU6NXzBbozaJg==",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0",
+        "undici": "6.19.7"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^1.18.1"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.3.tgz",
+      "integrity": "sha512-Fc9wuJGgxoxQeavybiuwgyi+0rssr76b+nHpj+eGhXFYAdudMWyfBHvFL/I5fEHniUM/UQdFzi9VXJK2iZF7FQ=="
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.12.2.tgz",
+      "integrity": "sha512-qsEBaRMoGvHO10unlDJhaKSuPn4pyoTtlQuP1ghZfzB6rNQPuhp/N/DcFZxm9i4v0SogjCbf9reWupwIvfmH6w==",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.9.tgz",
+      "integrity": "sha512-gm8EUEJE/fEac86AvHn8Z/QW8BvR56TBw3hMW0O838J/1mThYQXAIQBgUv75EqlCZfdawpWLrKt1uXvp9ciK3Q==",
+      "dependencies": {
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.1.0.tgz",
+      "integrity": "sha512-vSe5s8dY13ilhLnfY0eYRmQsdTbH7PUFZtBbqU6JVX/j8Qp9A6G5gG6//ulbX9/1JFOF1IWNOne9c8S/DOCJaQ==",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.3",
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.8.tgz",
+      "integrity": "sha512-dzXALZeBI1U5TXt6619cv0+tgEhJiwlUtQ55WNZY7vGAjv7Q1QioV969iYwt1AQQ0ovHnEW0YW9TiBfefLvErg==",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.2",
+        "@firebase/auth-interop-types": "0.2.3",
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-1.0.8.tgz",
+      "integrity": "sha512-OpeWZoPE3sGIRPBKYnW9wLad25RaWbGyk7fFQe4xnJQKRzlynWeFBSRRAoLE2Old01WXwskUiucNqUUVlFsceg==",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/database": "1.0.8",
+        "@firebase/database-types": "1.0.5",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.5.tgz",
+      "integrity": "sha512-fTlqCNwFYyq/C6W7AJ5OCuq5CeZuBEsEwptnVxlNPkWCo5cTTyukzAHRSO/jaQcItz33FfYrrFk1SJofcu2AaQ==",
+      "dependencies": {
+        "@firebase/app-types": "0.9.2",
+        "@firebase/util": "1.10.0"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.7.3.tgz",
+      "integrity": "sha512-NwVU+JPZ/3bhvNSJMCSzfcBZZg8SUGyzZ2T0EW3/bkUeefCyzMISSt/TTIfEHc8cdyXGlMqfGe3/62u9s74UEg==",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "@firebase/webchannel-wrapper": "1.0.1",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0",
+        "undici": "6.19.7"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.3.38",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.38.tgz",
+      "integrity": "sha512-GoS0bIMMkjpLni6StSwRJarpu2+S5m346Na7gr9YZ/BZ/W3/8iHGNr9PxC+f0rNZXqS4fGRn88pICjrZEgbkqQ==",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/firestore": "4.7.3",
+        "@firebase/firestore-types": "3.0.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.2.tgz",
+      "integrity": "sha512-wp1A+t5rI2Qc/2q7r2ZpjUXkRVPtGMd6zCLsiWurjsQpqPgFin3AhNibKcIzoF2rnToNa/XYtyWXuifjOOwDgg==",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.11.8.tgz",
+      "integrity": "sha512-Lo2rTPDn96naFIlSZKVd1yvRRqqqwiJk7cf9TZhUerwnPKgBzXy+aHE22ry+6EjCaQusUoNai6mU6p+G8QZT1g==",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.2",
+        "@firebase/auth-interop-types": "0.2.3",
+        "@firebase/component": "0.6.9",
+        "@firebase/messaging-interop-types": "0.2.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0",
+        "undici": "6.19.7"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.14.tgz",
+      "integrity": "sha512-dZ0PKOKQFnOlMfcim39XzaXonSuPPAVuzpqA4ONTIdyaJK/OnBaIEVs/+BH4faa1a2tLeR+Jy15PKqDRQoNIJw==",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/functions": "0.11.8",
+        "@firebase/functions-types": "0.6.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.2.tgz",
+      "integrity": "sha512-0KiJ9lZ28nS2iJJvimpY4nNccV21rkQyor5Iheu/nq8aKXJqtJdeSlZDspjPSBBiHRzo7/GMUttegnsEITqR+w=="
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.9.tgz",
+      "integrity": "sha512-hlT7AwCiKghOX3XizLxXOsTFiFCQnp/oj86zp1UxwDGmyzsyoxtX+UIZyVyH/oBF5+XtblFG9KZzZQ/h+dpy+Q==",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/util": "1.10.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.9.tgz",
+      "integrity": "sha512-2lfdc6kPXR7WaL4FCQSQUhXcPbI7ol3wF+vkgtU25r77OxPf8F/VmswQ7sgIkBBWtymn5ZF20TIKtnOj9rjb6w==",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/installations": "0.6.9",
+        "@firebase/installations-types": "0.5.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.2.tgz",
+      "integrity": "sha512-que84TqGRZJpJKHBlF2pkvc1YcXrtEDOVGiDjovP/a3s6W4nlbohGXEsBJo0JCeeg/UG9A+DEZVDUV9GpklUzA==",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.2.tgz",
+      "integrity": "sha512-Q1VuA5M1Gjqrwom6I6NUU4lQXdo9IAQieXlujeHZWvRt1b7qQ0KwBaNAjgxG27jgF9/mUwsNmO8ptBCGVYhB0A==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.12",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.12.tgz",
+      "integrity": "sha512-6q0pbzYBJhZEtUoQx7hnPhZvAbuMNuBXKQXOx2YlWhSrlv9N1m0ZzlNpBbu/ItTzrwNKTibdYzUyaaxdWLg+4w==",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/installations": "0.6.9",
+        "@firebase/messaging-interop-types": "0.2.2",
+        "@firebase/util": "1.10.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.12.tgz",
+      "integrity": "sha512-pKsiUVZrbmRgdImYqhBNZlkKJbqjlPkVdQRZGRbkTyX4OSGKR0F/oJeCt1a8jEg5UnBp4fdVwSWSp4DuCovvEQ==",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/messaging": "0.12.12",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.2.tgz",
+      "integrity": "sha512-l68HXbuD2PPzDUOFb3aG+nZj5KA3INcPwlocwLZOzPp9rFM9yeuI9YLl6DQfguTX5eAGxO0doTR+rDLDvQb5tA=="
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.6.9.tgz",
+      "integrity": "sha512-PnVaak5sqfz5ivhua+HserxTJHtCar/7zM0flCX6NkzBNzJzyzlH4Hs94h2Il0LQB99roBqoE5QT1JqWqcLJHQ==",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/installations": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.9.tgz",
+      "integrity": "sha512-dNl95IUnpsu3fAfYBZDCVhXNkASE0uo4HYaEPd2/PKscfTvsgqFAOxfAXzBEDOnynDWiaGUnb5M1O00JQ+3FXA==",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/performance": "0.6.9",
+        "@firebase/performance-types": "0.2.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.2.tgz",
+      "integrity": "sha512-gVq0/lAClVH5STrIdKnHnCo2UcPLjJlDUoEB/tB4KM+hAeHUxWKnpT0nemUPvxZ5nbdY/pybeyMe8Cs29gEcHA=="
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.4.9.tgz",
+      "integrity": "sha512-EO1NLCWSPMHdDSRGwZ73kxEEcTopAxX1naqLJFNApp4hO8WfKfmEpmjxmP5TrrnypjIf2tUkYaKsfbEA7+AMmA==",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/installations": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.9.tgz",
+      "integrity": "sha512-AxzGpWfWFYejH2twxfdOJt5Cfh/ATHONegTd/a0p5flEzsD5JsxXgfkFToop+mypEL3gNwawxrxlZddmDoNxyA==",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/remote-config": "0.4.9",
+        "@firebase/remote-config-types": "0.3.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.3.2.tgz",
+      "integrity": "sha512-0BC4+Ud7y2aPTyhXJTMTFfrGGLqdYXrUB9sJVAB8NiqJswDTc4/2qrE/yfUbnQJhbSi6ZaTTBKyG3n1nplssaA=="
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.2.tgz",
+      "integrity": "sha512-fxuJnHshbhVwuJ4FuISLu+/76Aby2sh+44ztjF2ppoe0TELIDxPW6/r1KGlWYt//AD0IodDYYA8ZTN89q8YqUw==",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0",
+        "undici": "6.19.7"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.12.tgz",
+      "integrity": "sha512-hA4VWKyGU5bWOll+uwzzhEMMYGu9PlKQc1w4DWxB3aIErWYzonrZjF0icqNQZbwKNIdh8SHjZlFeB2w6OSsjfg==",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/storage": "0.13.2",
+        "@firebase/storage-types": "0.8.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.2.tgz",
+      "integrity": "sha512-0vWu99rdey0g53lA7IShoA2Lol1jfnPovzLDUBuon65K7uKG9G+L5uO05brD9pMw+l4HRFw23ah3GwTGpEav6g==",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.10.0.tgz",
+      "integrity": "sha512-xKtx4A668icQqoANRxyDLBLz51TAbDP9KRfpbKGxiCAW346d0BeJe5vN6/hKxxmWwnZ0mautyv39JxviwwQMOQ==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/vertexai-preview": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/vertexai-preview/-/vertexai-preview-0.0.4.tgz",
+      "integrity": "sha512-EBSqyu9eg8frQlVU9/HjKtHN7odqbh9MtAcVz3WwHj4gLCLOoN9F/o+oxlq3CxvFrd3CNTZwu6d2mZtVlEInng==",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.2",
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.1.tgz",
+      "integrity": "sha512-jmEnr/pk0yVkA7mIlHNnxCi+wWzOFUg0WyIotgkKAb2u1J7fAeDBcVNSTjTihbAYNusCLQdW5s9IJ5qwnEufcQ=="
+    },
+    "node_modules/@google-cloud/firestore": {
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.11.6.tgz",
+      "integrity": "sha512-EW/O8ktzwLfyWBOsNuhRoMi8lrC3clHM5LVFhGvO1HCsLozCOOXRAlHrYBoE6HL42Sc8yYMuCb2XqcnJ4OOEpw==",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0",
+        "fast-deep-equal": "^3.1.1",
+        "functional-red-black-tree": "^1.0.1",
+        "google-gax": "^4.3.3",
+        "protobufjs": "^7.2.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/paginator": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+      "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
+      "optional": true,
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+      "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
+      "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.21.0.tgz",
+      "integrity": "sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==",
+      "optional": true,
+      "dependencies": {
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "<4.1.0",
+        "abort-controller": "^3.0.0",
+        "async-retry": "^1.3.3",
+        "duplexify": "^4.1.3",
+        "fast-xml-parser": "^5.3.4",
+        "gaxios": "^6.0.2",
+        "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
+        "mime": "^3.0.0",
+        "p-limit": "^3.0.1",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.16",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.16.tgz",
+      "integrity": "sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "optional": true
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "optional": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.29.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.3.tgz",
+      "integrity": "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.8.tgz",
+      "integrity": "sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==",
+      "dependencies": {
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.5.tgz",
+      "integrity": "sha512-SuqeisTyPoiIPtIYru/sGxGyXzmZ+8nnFOhC+qRPglt06Ebd1yH//CDltZB2J/3WBNVhwfUaZ0EtHB3cm2X32g==",
+      "dependencies": {
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.5.tgz",
+      "integrity": "sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==",
+      "dependencies": {
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.4.tgz",
+      "integrity": "sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ==",
+      "dependencies": {
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/caseless": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+      "optional": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "optional": true
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/request": {
+      "version": "2.48.13",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
+      "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
+      "optional": true,
+      "dependencies": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.5"
+      }
+    },
+    "node_modules/@types/request/node_modules/form-data": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
+      "optional": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "optional": true
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "optional": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "optional": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "optional": true
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true
+    },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "optional": true,
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.2.tgz",
+      "integrity": "sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "browserslist": "^4.28.4",
+        "caniuse-lite": "^1.0.30001799",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "dev": true,
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001805",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
+      "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "optional": true
+    },
+    "node_modules/farmhash-modern": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/farmhash-modern/-/farmhash-modern-1.1.0.tgz",
+      "integrity": "sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "optional": true
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "optional": true,
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.0.tgz",
+      "integrity": "sha512-SLhnTEqE5QpJHq/6zl9bsmImEP2adv+y6Wy+cJa7nVTRzQh1OZfCe9k29M5xN74LWnu0xa1zrUrq3KnOKl92Fg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "optional": true,
+      "dependencies": {
+        "@nodable/entities": "^2.2.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "10.14.1",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-10.14.1.tgz",
+      "integrity": "sha512-0KZxU+Ela9rUCULqFsUUOYYkjh7OM1EWdIfG6///MtXd0t2/uUIf0iNV5i0KariMhRQ5jve/OY985nrAXFaZeQ==",
+      "dependencies": {
+        "@firebase/analytics": "0.10.8",
+        "@firebase/analytics-compat": "0.2.14",
+        "@firebase/app": "0.10.13",
+        "@firebase/app-check": "0.8.8",
+        "@firebase/app-check-compat": "0.3.15",
+        "@firebase/app-compat": "0.2.43",
+        "@firebase/app-types": "0.9.2",
+        "@firebase/auth": "1.7.9",
+        "@firebase/auth-compat": "0.5.14",
+        "@firebase/data-connect": "0.1.0",
+        "@firebase/database": "1.0.8",
+        "@firebase/database-compat": "1.0.8",
+        "@firebase/firestore": "4.7.3",
+        "@firebase/firestore-compat": "0.3.38",
+        "@firebase/functions": "0.11.8",
+        "@firebase/functions-compat": "0.3.14",
+        "@firebase/installations": "0.6.9",
+        "@firebase/installations-compat": "0.2.9",
+        "@firebase/messaging": "0.12.12",
+        "@firebase/messaging-compat": "0.2.12",
+        "@firebase/performance": "0.6.9",
+        "@firebase/performance-compat": "0.2.9",
+        "@firebase/remote-config": "0.4.9",
+        "@firebase/remote-config-compat": "0.2.9",
+        "@firebase/storage": "0.13.2",
+        "@firebase/storage-compat": "0.3.12",
+        "@firebase/util": "1.10.0",
+        "@firebase/vertexai-preview": "0.0.4"
+      }
+    },
+    "node_modules/firebase-admin": {
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.7.0.tgz",
+      "integrity": "sha512-raFIrOyTqREbyXsNkSHyciQLfv8AUZazehPaQS1lZBSCDYW74FYXU0nQZa3qHI4K+hawohlDbywZ4+qce9YNxA==",
+      "dependencies": {
+        "@fastify/busboy": "^3.0.0",
+        "@firebase/database-compat": "1.0.8",
+        "@firebase/database-types": "1.0.5",
+        "@types/node": "^22.0.1",
+        "farmhash-modern": "^1.1.0",
+        "jsonwebtoken": "^9.0.0",
+        "jwks-rsa": "^3.1.0",
+        "node-forge": "^1.3.1",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "@google-cloud/firestore": "^7.7.0",
+        "@google-cloud/storage": "^7.7.0"
+      }
+    },
+    "node_modules/firebase-admin/node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/firebase-admin/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+    },
+    "node_modules/firebase/node_modules/@firebase/auth": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.7.9.tgz",
+      "integrity": "sha512-yLD5095kVgDw965jepMyUrIgDklD6qH/BZNHeKOgvu7pchOKNjVM+zQoOVYJIKWMWOWBq8IRNVU6NXzBbozaJg==",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0",
+        "undici": "6.19.7"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^1.18.1"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "optional": true
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "optional": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.6.1.tgz",
+      "integrity": "sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==",
+      "optional": true,
+      "dependencies": {
+        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/proto-loader": "^0.7.13",
+        "@types/long": "^4.0.0",
+        "abort-controller": "^3.0.0",
+        "duplexify": "^4.0.0",
+        "google-auth-library": "^9.3.0",
+        "node-fetch": "^2.7.0",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^2.0.2",
+        "protobufjs": "^7.3.2",
+        "retry-request": "^7.0.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "optional": true,
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/google-gax/node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "optional": true,
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/google-gax/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "optional": true
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA=="
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "optional": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "optional": true
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "optional": true
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "optional": true,
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jwks-rsa": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.2.2.tgz",
+      "integrity": "sha512-BqTyEDV+lS8F2trk3A+qJnxV5Q9EqKCBJOPti3W97r7qTympCZjb7h2X6f2kc+0K3rsSTY1/6YG2eaXKoj497w==",
+      "dependencies": {
+        "@types/jsonwebtoken": "^9.0.4",
+        "debug": "^4.3.4",
+        "jose": "^4.15.4",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lru-memoizer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
+      "integrity": "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "6.0.0"
+      }
+    },
+    "node_modules/lru-memoizer/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lru-memoizer/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/mailgun.js": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/mailgun.js/-/mailgun.js-10.4.0.tgz",
+      "integrity": "sha512-YrdaZEAJwwjXGBTfZTNQ1LM7tmkdUaz2NpZEu7+zULcG4Wrlhd7cWSNZW0bxT3bP48k5N0mZWz8C2f9gc2+Geg==",
+      "dependencies": {
+        "axios": "^1.7.4",
+        "base-64": "^1.0.0",
+        "url-join": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "optional": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "optional": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "devOptional": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "optional": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
+    },
+    "node_modules/proto3-json-serializer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
+      "integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
+      "optional": true,
+      "dependencies": {
+        "protobufjs": "^7.2.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.2.0.tgz",
+      "integrity": "sha512-YietHHltOHA4+l5na1srdaMx4sVSOjV9tamHs+mwiLWAMr6QVACRUw1Neax5CptFILcNoITctJY0Ipyn5enQ8g==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "dependencies": {
+        "@remix-run/router": "1.23.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "dependencies": {
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/retry-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+      "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
+      "optional": true,
+      "dependencies": {
+        "@types/request": "^2.48.8",
+        "extend": "^3.0.2",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "optional": true,
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "optional": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "optional": true,
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "optional": true
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/teeny-request": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+      "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
+      "optional": true,
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.9",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/teeny-request/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/teeny-request/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "optional": true
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/undici": {
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.7.tgz",
+      "integrity": "sha512-HR3W/bMGPSr90i8AAp2C4DM3wChFdJPLrWYpIS++LxS8K+W535qftjt+4MyjNYHeWabMj1nvtmLIi7l++iq91A==",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "devOptional": true
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "optional": true
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "optional": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "optional": true
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "optional": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    }
+  },
+  "dependencies": {
+    "@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true
+    },
+    "@aws-sdk/checksums": {
+      "version": "3.1000.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.16.tgz",
+      "integrity": "sha512-EKnvkXSmz3IpA99tCNuI+dLFXyZyClSm8zns9sB/elvkU+MTuomAs6toJMPMBf98/fICG/urXDkzGz0/c3yyAQ==",
+      "requires": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/client-s3": {
+      "version": "3.1085.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1085.0.tgz",
+      "integrity": "sha512-O0xe8sR50AYkwxlvRRsV0qytEO2dtXQTQ1CF3YBBdE5xtVkbu27H0vGa1mjQi1/+fbYM80AWEIPai5jZmXyubw==",
+      "requires": {
+        "@aws-sdk/checksums": "^3.1000.16",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-node": "^3.972.66",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.62",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/core": {
+      "version": "3.975.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
+      "integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
+      "requires": {
+        "@aws-sdk/types": "^3.974.0",
+        "@aws-sdk/xml-builder": "^3.972.34",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
+      "integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
+      "requires": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-http": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
+      "integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
+      "requires": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
+      "integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
+      "requires": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-login": "^3.972.63",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-login": {
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
+      "integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
+      "requires": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.66.tgz",
+      "integrity": "sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-ini": "^3.973.1",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
+      "integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
+      "requires": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
+      "integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
+      "requires": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/token-providers": "3.1083.0",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
+      "integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
+      "requires": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.62",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.62.tgz",
+      "integrity": "sha512-k8JJwYXVYlOOjWnPZDThQS1xDFJgi5Dokt73qFlDtrZAbdcint5aIdjB9XgJAAQVP5OoqcefQmh1FYXiPpvsvw==",
+      "requires": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/nested-clients": {
+      "version": "3.997.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
+      "integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
+      "requires": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/s3-request-presigner": {
+      "version": "3.1085.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1085.0.tgz",
+      "integrity": "sha512-h8fv0zGAHPCjCpmAYdCeFE6trxXxLRxza0NRIajMZdnFgugtcIWcRAdAtc7rHvRTaXsej/I5YWXbq9SgKuCKow==",
+      "requires": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
+      "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
+      "requires": {
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.1083.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
+      "integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
+      "requires": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.974.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
+      "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
+      "requires": {
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/xml-builder": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
+      "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
+      "requires": {
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="
+    },
+    "@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      }
+    },
+    "@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true
+    },
+    "@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      }
+    },
+    "@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true
+    },
+    "@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true
+    },
+    "@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.29.7"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      }
+    },
+    "@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      }
+    },
+    "@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      }
+    },
+    "@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "dev": true,
+      "optional": true
+    },
+    "@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA=="
+    },
+    "@firebase/analytics": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.8.tgz",
+      "integrity": "sha512-CVnHcS4iRJPqtIDc411+UmFldk0ShSK3OB+D0bKD8Ck5Vro6dbK5+APZpkuWpbfdL359DIQUnAaMLE+zs/PVyA==",
+      "requires": {
+        "@firebase/component": "0.6.9",
+        "@firebase/installations": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/analytics-compat": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.14.tgz",
+      "integrity": "sha512-unRVY6SvRqfNFIAA/kwl4vK+lvQAL2HVcgu9zTrUtTyYDmtIt/lOuHJynBMYEgLnKm39YKBDhtqdapP2e++ASw==",
+      "requires": {
+        "@firebase/analytics": "0.10.8",
+        "@firebase/analytics-types": "0.8.2",
+        "@firebase/component": "0.6.9",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/analytics-types": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.2.tgz",
+      "integrity": "sha512-EnzNNLh+9/sJsimsA/FGqzakmrAUKLeJvjRHlg8df1f97NLUlFidk9600y0ZgWOp3CAxn6Hjtk+08tixlUOWyw=="
+    },
+    "@firebase/app": {
+      "version": "0.10.13",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.10.13.tgz",
+      "integrity": "sha512-OZiDAEK/lDB6xy/XzYAyJJkaDqmQ+BCtOEPLqFvxWKUz5JbBmej7IiiRHdtiIOD/twW7O5AxVsfaaGA/V1bNsA==",
+      "requires": {
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/app-check": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.8.8.tgz",
+      "integrity": "sha512-O49RGF1xj7k6BuhxGpHmqOW5hqBIAEbt2q6POW0lIywx7emYtzPDeQI+ryQpC4zbKX646SoVZ711TN1DBLNSOQ==",
+      "requires": {
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/app-check-compat": {
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.15.tgz",
+      "integrity": "sha512-zFIvIFFNqDXpOT2huorz9cwf56VT3oJYRFjSFYdSbGYEJYEaXjLJbfC79lx/zjx4Fh+yuN8pry3TtvwaevrGbg==",
+      "requires": {
+        "@firebase/app-check": "0.8.8",
+        "@firebase/app-check-types": "0.5.2",
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/app-check-interop-types": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.2.tgz",
+      "integrity": "sha512-LMs47Vinv2HBMZi49C09dJxp0QT5LwDzFaVGf/+ITHe3BlIhUiLNttkATSXplc89A2lAaeTqjgqVkiRfUGyQiQ=="
+    },
+    "@firebase/app-check-types": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.2.tgz",
+      "integrity": "sha512-FSOEzTzL5bLUbD2co3Zut46iyPWML6xc4x+78TeaXMSuJap5QObfb+rVvZJtla3asN4RwU7elaQaduP+HFizDA=="
+    },
+    "@firebase/app-compat": {
+      "version": "0.2.43",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.43.tgz",
+      "integrity": "sha512-HM96ZyIblXjAC7TzE8wIk2QhHlSvksYkQ4Ukh1GmEenzkucSNUmUX4QvoKrqeWsLEQ8hdcojABeCV8ybVyZmeg==",
+      "requires": {
+        "@firebase/app": "0.10.13",
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/app-types": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.2.tgz",
+      "integrity": "sha512-oMEZ1TDlBz479lmABwWsWjzHwheQKiAgnuKxE0pz0IXCVx7/rtlkx1fQ6GfgK24WCrxDKMplZrT50Kh04iMbXQ=="
+    },
+    "@firebase/auth-compat": {
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.14.tgz",
+      "integrity": "sha512-2eczCSqBl1KUPJacZlFpQayvpilg3dxXLy9cSMTKtQMTQSmondUtPI47P3ikH3bQAXhzKLOE+qVxJ3/IRtu9pw==",
+      "requires": {
+        "@firebase/auth": "1.7.9",
+        "@firebase/auth-types": "0.12.2",
+        "@firebase/component": "0.6.9",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0",
+        "undici": "6.19.7"
+      },
+      "dependencies": {
+        "@firebase/auth": {
+          "version": "1.7.9",
+          "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.7.9.tgz",
+          "integrity": "sha512-yLD5095kVgDw965jepMyUrIgDklD6qH/BZNHeKOgvu7pchOKNjVM+zQoOVYJIKWMWOWBq8IRNVU6NXzBbozaJg==",
+          "requires": {
+            "@firebase/component": "0.6.9",
+            "@firebase/logger": "0.4.2",
+            "@firebase/util": "1.10.0",
+            "tslib": "^2.1.0",
+            "undici": "6.19.7"
+          }
+        }
+      }
+    },
+    "@firebase/auth-interop-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.3.tgz",
+      "integrity": "sha512-Fc9wuJGgxoxQeavybiuwgyi+0rssr76b+nHpj+eGhXFYAdudMWyfBHvFL/I5fEHniUM/UQdFzi9VXJK2iZF7FQ=="
+    },
+    "@firebase/auth-types": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.12.2.tgz",
+      "integrity": "sha512-qsEBaRMoGvHO10unlDJhaKSuPn4pyoTtlQuP1ghZfzB6rNQPuhp/N/DcFZxm9i4v0SogjCbf9reWupwIvfmH6w==",
+      "requires": {}
+    },
+    "@firebase/component": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.9.tgz",
+      "integrity": "sha512-gm8EUEJE/fEac86AvHn8Z/QW8BvR56TBw3hMW0O838J/1mThYQXAIQBgUv75EqlCZfdawpWLrKt1uXvp9ciK3Q==",
+      "requires": {
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/data-connect": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.1.0.tgz",
+      "integrity": "sha512-vSe5s8dY13ilhLnfY0eYRmQsdTbH7PUFZtBbqU6JVX/j8Qp9A6G5gG6//ulbX9/1JFOF1IWNOne9c8S/DOCJaQ==",
+      "requires": {
+        "@firebase/auth-interop-types": "0.2.3",
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/database": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.8.tgz",
+      "integrity": "sha512-dzXALZeBI1U5TXt6619cv0+tgEhJiwlUtQ55WNZY7vGAjv7Q1QioV969iYwt1AQQ0ovHnEW0YW9TiBfefLvErg==",
+      "requires": {
+        "@firebase/app-check-interop-types": "0.3.2",
+        "@firebase/auth-interop-types": "0.2.3",
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/database-compat": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-1.0.8.tgz",
+      "integrity": "sha512-OpeWZoPE3sGIRPBKYnW9wLad25RaWbGyk7fFQe4xnJQKRzlynWeFBSRRAoLE2Old01WXwskUiucNqUUVlFsceg==",
+      "requires": {
+        "@firebase/component": "0.6.9",
+        "@firebase/database": "1.0.8",
+        "@firebase/database-types": "1.0.5",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/database-types": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.5.tgz",
+      "integrity": "sha512-fTlqCNwFYyq/C6W7AJ5OCuq5CeZuBEsEwptnVxlNPkWCo5cTTyukzAHRSO/jaQcItz33FfYrrFk1SJofcu2AaQ==",
+      "requires": {
+        "@firebase/app-types": "0.9.2",
+        "@firebase/util": "1.10.0"
+      }
+    },
+    "@firebase/firestore": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.7.3.tgz",
+      "integrity": "sha512-NwVU+JPZ/3bhvNSJMCSzfcBZZg8SUGyzZ2T0EW3/bkUeefCyzMISSt/TTIfEHc8cdyXGlMqfGe3/62u9s74UEg==",
+      "requires": {
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "@firebase/webchannel-wrapper": "1.0.1",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0",
+        "undici": "6.19.7"
+      }
+    },
+    "@firebase/firestore-compat": {
+      "version": "0.3.38",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.38.tgz",
+      "integrity": "sha512-GoS0bIMMkjpLni6StSwRJarpu2+S5m346Na7gr9YZ/BZ/W3/8iHGNr9PxC+f0rNZXqS4fGRn88pICjrZEgbkqQ==",
+      "requires": {
+        "@firebase/component": "0.6.9",
+        "@firebase/firestore": "4.7.3",
+        "@firebase/firestore-types": "3.0.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/firestore-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.2.tgz",
+      "integrity": "sha512-wp1A+t5rI2Qc/2q7r2ZpjUXkRVPtGMd6zCLsiWurjsQpqPgFin3AhNibKcIzoF2rnToNa/XYtyWXuifjOOwDgg==",
+      "requires": {}
+    },
+    "@firebase/functions": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.11.8.tgz",
+      "integrity": "sha512-Lo2rTPDn96naFIlSZKVd1yvRRqqqwiJk7cf9TZhUerwnPKgBzXy+aHE22ry+6EjCaQusUoNai6mU6p+G8QZT1g==",
+      "requires": {
+        "@firebase/app-check-interop-types": "0.3.2",
+        "@firebase/auth-interop-types": "0.2.3",
+        "@firebase/component": "0.6.9",
+        "@firebase/messaging-interop-types": "0.2.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0",
+        "undici": "6.19.7"
+      }
+    },
+    "@firebase/functions-compat": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.14.tgz",
+      "integrity": "sha512-dZ0PKOKQFnOlMfcim39XzaXonSuPPAVuzpqA4ONTIdyaJK/OnBaIEVs/+BH4faa1a2tLeR+Jy15PKqDRQoNIJw==",
+      "requires": {
+        "@firebase/component": "0.6.9",
+        "@firebase/functions": "0.11.8",
+        "@firebase/functions-types": "0.6.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/functions-types": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.2.tgz",
+      "integrity": "sha512-0KiJ9lZ28nS2iJJvimpY4nNccV21rkQyor5Iheu/nq8aKXJqtJdeSlZDspjPSBBiHRzo7/GMUttegnsEITqR+w=="
+    },
+    "@firebase/installations": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.9.tgz",
+      "integrity": "sha512-hlT7AwCiKghOX3XizLxXOsTFiFCQnp/oj86zp1UxwDGmyzsyoxtX+UIZyVyH/oBF5+XtblFG9KZzZQ/h+dpy+Q==",
+      "requires": {
+        "@firebase/component": "0.6.9",
+        "@firebase/util": "1.10.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/installations-compat": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.9.tgz",
+      "integrity": "sha512-2lfdc6kPXR7WaL4FCQSQUhXcPbI7ol3wF+vkgtU25r77OxPf8F/VmswQ7sgIkBBWtymn5ZF20TIKtnOj9rjb6w==",
+      "requires": {
+        "@firebase/component": "0.6.9",
+        "@firebase/installations": "0.6.9",
+        "@firebase/installations-types": "0.5.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/installations-types": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.2.tgz",
+      "integrity": "sha512-que84TqGRZJpJKHBlF2pkvc1YcXrtEDOVGiDjovP/a3s6W4nlbohGXEsBJo0JCeeg/UG9A+DEZVDUV9GpklUzA==",
+      "requires": {}
+    },
+    "@firebase/logger": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.2.tgz",
+      "integrity": "sha512-Q1VuA5M1Gjqrwom6I6NUU4lQXdo9IAQieXlujeHZWvRt1b7qQ0KwBaNAjgxG27jgF9/mUwsNmO8ptBCGVYhB0A==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/messaging": {
+      "version": "0.12.12",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.12.tgz",
+      "integrity": "sha512-6q0pbzYBJhZEtUoQx7hnPhZvAbuMNuBXKQXOx2YlWhSrlv9N1m0ZzlNpBbu/ItTzrwNKTibdYzUyaaxdWLg+4w==",
+      "requires": {
+        "@firebase/component": "0.6.9",
+        "@firebase/installations": "0.6.9",
+        "@firebase/messaging-interop-types": "0.2.2",
+        "@firebase/util": "1.10.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/messaging-compat": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.12.tgz",
+      "integrity": "sha512-pKsiUVZrbmRgdImYqhBNZlkKJbqjlPkVdQRZGRbkTyX4OSGKR0F/oJeCt1a8jEg5UnBp4fdVwSWSp4DuCovvEQ==",
+      "requires": {
+        "@firebase/component": "0.6.9",
+        "@firebase/messaging": "0.12.12",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/messaging-interop-types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.2.tgz",
+      "integrity": "sha512-l68HXbuD2PPzDUOFb3aG+nZj5KA3INcPwlocwLZOzPp9rFM9yeuI9YLl6DQfguTX5eAGxO0doTR+rDLDvQb5tA=="
+    },
+    "@firebase/performance": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.6.9.tgz",
+      "integrity": "sha512-PnVaak5sqfz5ivhua+HserxTJHtCar/7zM0flCX6NkzBNzJzyzlH4Hs94h2Il0LQB99roBqoE5QT1JqWqcLJHQ==",
+      "requires": {
+        "@firebase/component": "0.6.9",
+        "@firebase/installations": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/performance-compat": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.9.tgz",
+      "integrity": "sha512-dNl95IUnpsu3fAfYBZDCVhXNkASE0uo4HYaEPd2/PKscfTvsgqFAOxfAXzBEDOnynDWiaGUnb5M1O00JQ+3FXA==",
+      "requires": {
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/performance": "0.6.9",
+        "@firebase/performance-types": "0.2.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/performance-types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.2.tgz",
+      "integrity": "sha512-gVq0/lAClVH5STrIdKnHnCo2UcPLjJlDUoEB/tB4KM+hAeHUxWKnpT0nemUPvxZ5nbdY/pybeyMe8Cs29gEcHA=="
+    },
+    "@firebase/remote-config": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.4.9.tgz",
+      "integrity": "sha512-EO1NLCWSPMHdDSRGwZ73kxEEcTopAxX1naqLJFNApp4hO8WfKfmEpmjxmP5TrrnypjIf2tUkYaKsfbEA7+AMmA==",
+      "requires": {
+        "@firebase/component": "0.6.9",
+        "@firebase/installations": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/remote-config-compat": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.9.tgz",
+      "integrity": "sha512-AxzGpWfWFYejH2twxfdOJt5Cfh/ATHONegTd/a0p5flEzsD5JsxXgfkFToop+mypEL3gNwawxrxlZddmDoNxyA==",
+      "requires": {
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/remote-config": "0.4.9",
+        "@firebase/remote-config-types": "0.3.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/remote-config-types": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.3.2.tgz",
+      "integrity": "sha512-0BC4+Ud7y2aPTyhXJTMTFfrGGLqdYXrUB9sJVAB8NiqJswDTc4/2qrE/yfUbnQJhbSi6ZaTTBKyG3n1nplssaA=="
+    },
+    "@firebase/storage": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.2.tgz",
+      "integrity": "sha512-fxuJnHshbhVwuJ4FuISLu+/76Aby2sh+44ztjF2ppoe0TELIDxPW6/r1KGlWYt//AD0IodDYYA8ZTN89q8YqUw==",
+      "requires": {
+        "@firebase/component": "0.6.9",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0",
+        "undici": "6.19.7"
+      }
+    },
+    "@firebase/storage-compat": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.12.tgz",
+      "integrity": "sha512-hA4VWKyGU5bWOll+uwzzhEMMYGu9PlKQc1w4DWxB3aIErWYzonrZjF0icqNQZbwKNIdh8SHjZlFeB2w6OSsjfg==",
+      "requires": {
+        "@firebase/component": "0.6.9",
+        "@firebase/storage": "0.13.2",
+        "@firebase/storage-types": "0.8.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/storage-types": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.2.tgz",
+      "integrity": "sha512-0vWu99rdey0g53lA7IShoA2Lol1jfnPovzLDUBuon65K7uKG9G+L5uO05brD9pMw+l4HRFw23ah3GwTGpEav6g==",
+      "requires": {}
+    },
+    "@firebase/util": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.10.0.tgz",
+      "integrity": "sha512-xKtx4A668icQqoANRxyDLBLz51TAbDP9KRfpbKGxiCAW346d0BeJe5vN6/hKxxmWwnZ0mautyv39JxviwwQMOQ==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/vertexai-preview": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/vertexai-preview/-/vertexai-preview-0.0.4.tgz",
+      "integrity": "sha512-EBSqyu9eg8frQlVU9/HjKtHN7odqbh9MtAcVz3WwHj4gLCLOoN9F/o+oxlq3CxvFrd3CNTZwu6d2mZtVlEInng==",
+      "requires": {
+        "@firebase/app-check-interop-types": "0.3.2",
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@firebase/webchannel-wrapper": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.1.tgz",
+      "integrity": "sha512-jmEnr/pk0yVkA7mIlHNnxCi+wWzOFUg0WyIotgkKAb2u1J7fAeDBcVNSTjTihbAYNusCLQdW5s9IJ5qwnEufcQ=="
+    },
+    "@google-cloud/firestore": {
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.11.6.tgz",
+      "integrity": "sha512-EW/O8ktzwLfyWBOsNuhRoMi8lrC3clHM5LVFhGvO1HCsLozCOOXRAlHrYBoE6HL42Sc8yYMuCb2XqcnJ4OOEpw==",
+      "optional": true,
+      "requires": {
+        "@opentelemetry/api": "^1.3.0",
+        "fast-deep-equal": "^3.1.1",
+        "functional-red-black-tree": "^1.0.1",
+        "google-gax": "^4.3.3",
+        "protobufjs": "^7.2.6"
+      }
+    },
+    "@google-cloud/paginator": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+      "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
+      "optional": true,
+      "requires": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      }
+    },
+    "@google-cloud/projectify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+      "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+      "optional": true
+    },
+    "@google-cloud/promisify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
+      "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
+      "optional": true
+    },
+    "@google-cloud/storage": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.21.0.tgz",
+      "integrity": "sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==",
+      "optional": true,
+      "requires": {
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "<4.1.0",
+        "abort-controller": "^3.0.0",
+        "async-retry": "^1.3.3",
+        "duplexify": "^4.1.3",
+        "fast-xml-parser": "^5.3.4",
+        "gaxios": "^6.0.2",
+        "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
+        "mime": "^3.0.0",
+        "p-limit": "^3.0.1",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0"
+      }
+    },
+    "@grpc/grpc-js": {
+      "version": "1.9.16",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.16.tgz",
+      "integrity": "sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==",
+      "requires": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      }
+    },
+    "@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "requires": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      }
+    },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "optional": true
+    },
+    "@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "optional": true
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
+    "@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "optional": true
+    },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="
+    },
+    "@remix-run/router": {
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q=="
+    },
+    "@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true
+    },
+    "@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "dev": true,
+      "optional": true
+    },
+    "@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "dev": true,
+      "optional": true
+    },
+    "@smithy/core": {
+      "version": "3.29.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.3.tgz",
+      "integrity": "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==",
+      "requires": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/credential-provider-imds": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.8.tgz",
+      "integrity": "sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==",
+      "requires": {
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/fetch-http-handler": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.5.tgz",
+      "integrity": "sha512-SuqeisTyPoiIPtIYru/sGxGyXzmZ+8nnFOhC+qRPglt06Ebd1yH//CDltZB2J/3WBNVhwfUaZ0EtHB3cm2X32g==",
+      "requires": {
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/node-http-handler": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.5.tgz",
+      "integrity": "sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==",
+      "requires": {
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/signature-v4": {
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.4.tgz",
+      "integrity": "sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ==",
+      "requires": {
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "optional": true
+    },
+    "@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "@types/caseless": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+      "optional": true
+    },
+    "@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "requires": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "optional": true
+    },
+    "@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
+    },
+    "@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "requires": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "@types/request": {
+      "version": "2.48.13",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
+      "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
+      "optional": true,
+      "requires": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.5"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.6",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+          "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
+          "optional": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "es-set-tostringtag": "^2.1.0",
+            "hasown": "^2.0.4",
+            "mime-types": "^2.1.35",
+            "safe-buffer": "^5.2.1"
+          }
+        }
+      }
+    },
+    "@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "optional": true
+    },
+    "@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      }
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "optional": true,
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
+    "agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "optional": true
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true
+    },
+    "anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "optional": true
+    },
+    "arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true
+    },
+    "arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "optional": true
+    },
+    "async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "optional": true,
+      "requires": {
+        "retry": "0.13.1"
+      }
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "autoprefixer": {
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.2.tgz",
+      "integrity": "sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.28.4",
+        "caniuse-lite": "^1.0.30001799",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      }
+    },
+    "axios": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "requires": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+          "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        }
+      }
+    },
+    "base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "optional": true
+    },
+    "baseline-browser-mapping": {
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "dev": true
+    },
+    "bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "optional": true
+    },
+    "binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true
+    },
+    "bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="
+    },
+    "braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.1.1"
+      }
+    },
+    "browserslist": {
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "dev": true,
+      "requires": {
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      }
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
+    "call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      }
+    },
+    "camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001805",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
+      "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
+      "dev": true
+    },
+    "chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
+      }
+    },
+    "cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
+    "cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true
+    },
+    "debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "requires": {
+        "ms": "^2.1.3"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true
+    },
+    "dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
+    },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      }
+    },
+    "duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "optional": true,
+      "requires": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "electron-to-chromium": {
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "optional": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "requires": {
+        "es-errors": "^1.3.0"
+      }
+    },
+    "es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      }
+    },
+    "esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "requires": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "optional": true
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "optional": true
+    },
+    "farmhash-modern": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/farmhash-modern/-/farmhash-modern-1.1.0.tgz",
+      "integrity": "sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA=="
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "optional": true
+    },
+    "fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
+      }
+    },
+    "fast-xml-builder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+      "optional": true,
+      "requires": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "fast-xml-parser": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.0.tgz",
+      "integrity": "sha512-SLhnTEqE5QpJHq/6zl9bsmImEP2adv+y6Wy+cJa7nVTRzQh1OZfCe9k29M5xN74LWnu0xa1zrUrq3KnOKl92Fg==",
+      "optional": true,
+      "requires": {
+        "@nodable/entities": "^2.2.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "requires": {
+        "websocket-driver": ">=0.5.1"
+      }
+    },
+    "fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "firebase": {
+      "version": "10.14.1",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-10.14.1.tgz",
+      "integrity": "sha512-0KZxU+Ela9rUCULqFsUUOYYkjh7OM1EWdIfG6///MtXd0t2/uUIf0iNV5i0KariMhRQ5jve/OY985nrAXFaZeQ==",
+      "requires": {
+        "@firebase/analytics": "0.10.8",
+        "@firebase/analytics-compat": "0.2.14",
+        "@firebase/app": "0.10.13",
+        "@firebase/app-check": "0.8.8",
+        "@firebase/app-check-compat": "0.3.15",
+        "@firebase/app-compat": "0.2.43",
+        "@firebase/app-types": "0.9.2",
+        "@firebase/auth": "1.7.9",
+        "@firebase/auth-compat": "0.5.14",
+        "@firebase/data-connect": "0.1.0",
+        "@firebase/database": "1.0.8",
+        "@firebase/database-compat": "1.0.8",
+        "@firebase/firestore": "4.7.3",
+        "@firebase/firestore-compat": "0.3.38",
+        "@firebase/functions": "0.11.8",
+        "@firebase/functions-compat": "0.3.14",
+        "@firebase/installations": "0.6.9",
+        "@firebase/installations-compat": "0.2.9",
+        "@firebase/messaging": "0.12.12",
+        "@firebase/messaging-compat": "0.2.12",
+        "@firebase/performance": "0.6.9",
+        "@firebase/performance-compat": "0.2.9",
+        "@firebase/remote-config": "0.4.9",
+        "@firebase/remote-config-compat": "0.2.9",
+        "@firebase/storage": "0.13.2",
+        "@firebase/storage-compat": "0.3.12",
+        "@firebase/util": "1.10.0",
+        "@firebase/vertexai-preview": "0.0.4"
+      },
+      "dependencies": {
+        "@firebase/auth": {
+          "version": "1.7.9",
+          "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.7.9.tgz",
+          "integrity": "sha512-yLD5095kVgDw965jepMyUrIgDklD6qH/BZNHeKOgvu7pchOKNjVM+zQoOVYJIKWMWOWBq8IRNVU6NXzBbozaJg==",
+          "requires": {
+            "@firebase/component": "0.6.9",
+            "@firebase/logger": "0.4.2",
+            "@firebase/util": "1.10.0",
+            "tslib": "^2.1.0",
+            "undici": "6.19.7"
+          }
+        }
+      }
+    },
+    "firebase-admin": {
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.7.0.tgz",
+      "integrity": "sha512-raFIrOyTqREbyXsNkSHyciQLfv8AUZazehPaQS1lZBSCDYW74FYXU0nQZa3qHI4K+hawohlDbywZ4+qce9YNxA==",
+      "requires": {
+        "@fastify/busboy": "^3.0.0",
+        "@firebase/database-compat": "1.0.8",
+        "@firebase/database-types": "1.0.5",
+        "@google-cloud/firestore": "^7.7.0",
+        "@google-cloud/storage": "^7.7.0",
+        "@types/node": "^22.0.1",
+        "farmhash-modern": "^1.1.0",
+        "jsonwebtoken": "^9.0.0",
+        "jwks-rsa": "^3.1.0",
+        "node-forge": "^1.3.1",
+        "uuid": "^10.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "22.20.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+          "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+          "requires": {
+            "undici-types": "~6.21.0"
+          }
+        },
+        "undici-types": {
+          "version": "6.21.0",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+          "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+        }
+      }
+    },
+    "follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
+    },
+    "form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      }
+    },
+    "fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "optional": true
+    },
+    "gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "optional": true,
+      "requires": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+          "optional": true
+        }
+      }
+    },
+    "gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "optional": true,
+      "requires": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      }
+    },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
+    "get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      }
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.3"
+      }
+    },
+    "google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "optional": true,
+      "requires": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      }
+    },
+    "google-gax": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.6.1.tgz",
+      "integrity": "sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==",
+      "optional": true,
+      "requires": {
+        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/proto-loader": "^0.7.13",
+        "@types/long": "^4.0.0",
+        "abort-controller": "^3.0.0",
+        "duplexify": "^4.0.0",
+        "google-auth-library": "^9.3.0",
+        "node-fetch": "^2.7.0",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^2.0.2",
+        "protobufjs": "^7.3.2",
+        "retry-request": "^7.0.0",
+        "uuid": "^9.0.1"
+      },
+      "dependencies": {
+        "@grpc/grpc-js": {
+          "version": "1.14.4",
+          "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+          "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+          "optional": true,
+          "requires": {
+            "@grpc/proto-loader": "^0.8.0",
+            "@js-sdsl/ordered-map": "^4.4.2"
+          },
+          "dependencies": {
+            "@grpc/proto-loader": {
+              "version": "0.8.1",
+              "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+              "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+              "optional": true,
+              "requires": {
+                "lodash.camelcase": "^4.3.0",
+                "long": "^5.0.0",
+                "protobufjs": "^7.5.5",
+                "yargs": "^17.7.2"
+              }
+            }
+          }
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+          "optional": true
+        }
+      }
+    },
+    "google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "optional": true
+    },
+    "gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "optional": true,
+      "requires": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      }
+    },
+    "has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "requires": {
+        "has-symbols": "^1.0.3"
+      }
+    },
+    "hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "requires": {
+        "function-bind": "^1.1.2"
+      }
+    },
+    "html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "optional": true
+    },
+    "http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA=="
+    },
+    "http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "optional": true,
+      "requires": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "optional": true,
+          "requires": {
+            "debug": "4"
+          }
+        }
+      }
+    },
+    "https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "optional": true,
+      "requires": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      }
+    },
+    "idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "optional": true
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "requires": {
+        "hasown": "^2.0.3"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "optional": true
+    },
+    "is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "optional": true
+    },
+    "jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true
+    },
+    "jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA=="
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true
+    },
+    "json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "optional": true,
+      "requires": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true
+    },
+    "jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "requires": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.8.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+          "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="
+        }
+      }
+    },
+    "jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "requires": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jwks-rsa": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.2.2.tgz",
+      "integrity": "sha512-BqTyEDV+lS8F2trk3A+qJnxV5Q9EqKCBJOPti3W97r7qTympCZjb7h2X6f2kc+0K3rsSTY1/6YG2eaXKoj497w==",
+      "requires": {
+        "@types/jsonwebtoken": "^9.0.4",
+        "debug": "^4.3.4",
+        "jose": "^4.15.4",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.2.0"
+      }
+    },
+    "jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "requires": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true
+    },
+    "limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
+    "lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+    },
+    "long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "requires": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "lru-memoizer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
+      "integrity": "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==",
+      "requires": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "mailgun.js": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/mailgun.js/-/mailgun.js-10.4.0.tgz",
+      "integrity": "sha512-YrdaZEAJwwjXGBTfZTNQ1LM7tmkdUaz2NpZEu7+zULcG4Wrlhd7cWSNZW0bxT3bP48k5N0mZWz8C2f9gc2+Geg==",
+      "requires": {
+        "axios": "^1.7.4",
+        "base-64": "^1.0.0",
+        "url-join": "^4.0.1"
+      }
+    },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      }
+    },
+    "mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "optional": true
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
+    "ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "requires": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "optional": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
+    "node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ=="
+    },
+    "node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true
+    },
+    "object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "devOptional": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "optional": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "optional": true,
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
+    },
+    "path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "optional": true
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true
+    },
+    "pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true
+    },
+    "postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "requires": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "requires": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      }
+    },
+    "postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "requires": {
+        "camelcase-css": "^2.0.1"
+      }
+    },
+    "postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "requires": {
+        "lilconfig": "^3.1.1"
+      }
+    },
+    "postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "requires": {
+        "postcss-selector-parser": "^6.1.1"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "dev": true,
+      "requires": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
+    },
+    "proto3-json-serializer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
+      "integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
+      "optional": true,
+      "requires": {
+        "protobufjs": "^7.2.5"
+      }
+    },
+    "protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      }
+    },
+    "proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
+    },
+    "qrcode.react": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.2.0.tgz",
+      "integrity": "sha512-YietHHltOHA4+l5na1srdaMx4sVSOjV9tamHs+mwiLWAMr6QVACRUw1Neax5CptFILcNoITctJY0Ipyn5enQ8g==",
+      "requires": {}
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
+    "react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "requires": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      }
+    },
+    "react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true
+    },
+    "react-router": {
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "requires": {
+        "@remix-run/router": "1.23.3"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "requires": {
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
+      }
+    },
+    "read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "requires": {
+        "pify": "^2.3.0"
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "optional": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
+    },
+    "resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
+    "retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "optional": true
+    },
+    "retry-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+      "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
+      "optional": true,
+      "requires": {
+        "@types/request": "^2.48.8",
+        "extend": "^3.0.2",
+        "teeny-request": "^9.0.0"
+      }
+    },
+    "reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true
+    },
+    "rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "requires": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "@types/estree": "1.0.9",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "requires": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true
+    },
+    "source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true
+    },
+    "stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "optional": true,
+      "requires": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "optional": true
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "optional": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "optional": true,
+      "requires": {
+        "anynum": "^1.0.1"
+      }
+    },
+    "stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "optional": true
+    },
+    "sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
+    },
+    "tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "requires": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      }
+    },
+    "teeny-request": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+      "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
+      "optional": true,
+      "requires": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.9",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "optional": true,
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+          "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+          "optional": true,
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+          "optional": true
+        }
+      }
+    },
+    "thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "requires": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "requires": {
+        "thenify": ">= 3.1.0 < 4"
+      }
+    },
+    "tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "requires": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "dependencies": {
+        "fdir": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+          "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+          "dev": true,
+          "requires": {}
+        },
+        "picomatch": {
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+          "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+          "dev": true
+        }
+      }
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "optional": true
+    },
+    "ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true
+    },
+    "tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "undici": {
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.7.tgz",
+      "integrity": "sha512-HR3W/bMGPSr90i8AAp2C4DM3wChFdJPLrWYpIS++LxS8K+W535qftjt+4MyjNYHeWabMj1nvtmLIi7l++iq91A=="
+    },
+    "undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="
+    },
+    "update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "requires": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      }
+    },
+    "url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
+    },
+    "use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "requires": {}
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "devOptional": true
+    },
+    "uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
+    },
+    "vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "requires": {
+        "esbuild": "^0.21.3",
+        "fsevents": "~2.3.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "optional": true
+    },
+    "websocket-driver": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
+      "requires": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "optional": true,
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "optional": true
+    },
+    "xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "optional": true
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+    },
+    "yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "requires": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      }
+    },
+    "yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "optional": true
+    },
+    "zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "requires": {
+        "use-sync-external-store": "^1.2.2"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,10 +3,15 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test test/*.test.js",
+    "check": "npm test && npm run build"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.598.0",

--- a/server/http.js
+++ b/server/http.js
@@ -1,0 +1,121 @@
+const DEFAULT_BODY_LIMIT_BYTES = 8 * 1024;
+
+export class HttpError extends Error {
+  constructor(status, message, options = {}) {
+    super(message, options.cause ? { cause: options.cause } : undefined);
+    this.name = 'HttpError';
+    this.status = status;
+    this.retryAfter = options.retryAfter || null;
+    this.code = options.code || null;
+  }
+}
+
+export function setPrivateJsonHeaders(res) {
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.setHeader('Cache-Control', 'private, no-store, max-age=0');
+  res.setHeader('Pragma', 'no-cache');
+  res.setHeader('Expires', '0');
+  res.setHeader('Referrer-Policy', 'no-referrer');
+  res.setHeader('Vary', 'Authorization, Cookie');
+}
+
+export function rejectMethod(res, allowedMethods) {
+  const methods = Array.isArray(allowedMethods) ? allowedMethods : [allowedMethods];
+  res.setHeader('Allow', methods.join(', '));
+  return res.status(405).json({ error: 'Method Not Allowed' });
+}
+
+export function parseJsonBody(req, maxBytes = DEFAULT_BODY_LIMIT_BYTES) {
+  const body = req?.body;
+
+  if (body && typeof body === 'object' && !Array.isArray(body) && !Buffer.isBuffer(body)) {
+    let serialized;
+    try {
+      serialized = JSON.stringify(body);
+    } catch (error) {
+      throw new HttpError(400, 'The request body must be valid JSON.', { cause: error });
+    }
+    if (Buffer.byteLength(serialized, 'utf8') > maxBytes) {
+      throw new HttpError(413, 'The request body is too large.');
+    }
+    return body;
+  }
+
+  let text = '';
+  if (typeof body === 'string') {
+    text = body;
+  } else if (Buffer.isBuffer(body)) {
+    text = body.toString('utf8');
+  } else if (body == null || body === '') {
+    return {};
+  } else {
+    throw new HttpError(400, 'The request body must be a JSON object.');
+  }
+
+  if (Buffer.byteLength(text, 'utf8') > maxBytes) {
+    throw new HttpError(413, 'The request body is too large.');
+  }
+
+  try {
+    const parsed = JSON.parse(text);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('JSON body is not an object');
+    }
+    return parsed;
+  } catch (error) {
+    throw new HttpError(400, 'The request body must be valid JSON.', { cause: error });
+  }
+}
+
+export function getSingleQueryValue(value) {
+  if (Array.isArray(value)) {
+    if (value.length !== 1) {
+      throw new HttpError(400, 'Invalid package access token.');
+    }
+    return value[0];
+  }
+  return value;
+}
+
+export function readBearerToken(req) {
+  const header = req?.headers?.authorization;
+  if (header == null || header === '') return null;
+  if (Array.isArray(header) || typeof header !== 'string') {
+    throw new HttpError(400, 'Invalid package access token.');
+  }
+
+  const match = header.match(/^Bearer[ \t]+([^ \t]+)$/i);
+  if (!match) {
+    throw new HttpError(400, 'Invalid package access token.');
+  }
+  return match[1];
+}
+
+export function sanitizeRetryAfter(value, now = Date.now()) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+
+  if (/^\d{1,6}$/.test(trimmed)) {
+    return String(Math.min(Math.max(Number(trimmed), 1), 86_400));
+  }
+
+  const timestamp = Date.parse(trimmed);
+  if (!Number.isFinite(timestamp) || timestamp <= now || timestamp - now > 7 * 86_400_000) {
+    return null;
+  }
+  return new Date(timestamp).toUTCString();
+}
+
+export function sendError(res, error, fallbackStatus = 500) {
+  const isHttpError = error instanceof HttpError;
+  const status = isHttpError ? error.status : fallbackStatus;
+  const message = isHttpError
+    ? error.message
+    : 'The package service is temporarily unavailable. Please try again shortly.';
+
+  if (isHttpError && error.retryAfter) {
+    res.setHeader('Retry-After', error.retryAfter);
+  }
+
+  return res.status(status).json({ error: message });
+}

--- a/server/legacy-customer.js
+++ b/server/legacy-customer.js
@@ -1,0 +1,161 @@
+import { HttpError } from './http.js';
+import { sanitizePublicUrl } from './package-portal.js';
+
+let defaultDatabasePromise = null;
+
+function requireFirebaseEnvironment(env) {
+  const projectId = env.FIREBASE_PROJECT_ID;
+  const clientEmail = env.FIREBASE_CLIENT_EMAIL;
+  const privateKey = env.FIREBASE_PRIVATE_KEY;
+  if (![projectId, clientEmail, privateKey].every((value) => typeof value === 'string' && value.trim())) {
+    throw new HttpError(503, 'The package service is temporarily unavailable. Please try again shortly.', {
+      code: 'LEGACY_NOT_CONFIGURED'
+    });
+  }
+  return {
+    projectId: projectId.trim(),
+    clientEmail: clientEmail.trim(),
+    privateKey: privateKey.replace(/\\n/g, '\n')
+  };
+}
+
+async function createDefaultDatabase(env = process.env) {
+  const credentials = requireFirebaseEnvironment(env);
+  try {
+    const imported = await import('firebase-admin');
+    const admin = imported.default || imported;
+    if (!admin.apps.length) {
+      admin.initializeApp({ credential: admin.credential.cert(credentials) });
+    }
+    return admin.firestore();
+  } catch (error) {
+    if (error instanceof HttpError) throw error;
+    throw new HttpError(503, 'The package service is temporarily unavailable. Please try again shortly.', {
+      code: 'LEGACY_UNAVAILABLE',
+      cause: error
+    });
+  }
+}
+
+async function getDefaultDatabase(env = process.env) {
+  if (!defaultDatabasePromise) {
+    defaultDatabasePromise = createDefaultDatabase(env).catch((error) => {
+      defaultDatabasePromise = null;
+      throw error;
+    });
+  }
+  return defaultDatabasePromise;
+}
+
+function boundedString(value, maxLength = 2_000) {
+  if (typeof value !== 'string') return '';
+  return value.slice(0, maxLength);
+}
+
+function timestampToIso(value) {
+  if (value == null) return null;
+  try {
+    const date = typeof value.toDate === 'function'
+      ? value.toDate()
+      : value instanceof Date
+        ? value
+        : new Date(value);
+    return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+function sanitizeLegacyDocument(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const url = sanitizePublicUrl(value.url);
+  const category = boundedString(value.category, 100).trim();
+  const name = boundedString(value.name, 500).trim();
+  if (!url || !category || !name) return null;
+  return {
+    id: ['string', 'number'].includes(typeof value.id) ? String(value.id).slice(0, 200) : '',
+    category,
+    name,
+    url
+  };
+}
+
+function sanitizeLegacyChecklistItem(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const text = boundedString(value.text, 2_000).trim();
+  if (!text) return null;
+  return {
+    id: ['string', 'number'].includes(typeof value.id) ? String(value.id).slice(0, 200) : '',
+    text,
+    completed: value.completed === true
+  };
+}
+
+function sanitizeLegacyKeyInformation(value) {
+  const source = value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+  return {
+    agentName: boundedString(source.agentName, 500),
+    agentContact: boundedString(source.agentContact, 500),
+    whatsAppNotes: boundedString(source.whatsAppNotes, 5_000),
+    groundTransportManager: boundedString(source.groundTransportManager, 1_000),
+    customerSim: boundedString(source.customerSim, 500),
+    customerEmail: boundedString(source.customerEmail, 500),
+    isEmailLocked: source.isEmailLocked === true
+  };
+}
+
+export function sanitizeLegacyCustomer(documentId, customerData) {
+  const source = customerData && typeof customerData === 'object' ? customerData : {};
+  const documents = Array.isArray(source.documents)
+    ? source.documents.slice(0, 500).map(sanitizeLegacyDocument).filter(Boolean)
+    : [];
+  const checklist = Array.isArray(source.checklist)
+    ? source.checklist.slice(0, 200).map(sanitizeLegacyChecklistItem).filter(Boolean)
+    : [];
+
+  return {
+    id: boundedString(String(documentId || ''), 200),
+    firstName: boundedString(source.firstName, 500),
+    lastName: boundedString(source.lastName, 500),
+    referenceNumber: boundedString(source.referenceNumber, 100),
+    packageType: boundedString(source.packageType, 500),
+    destination: boundedString(source.destination, 1_000),
+    documents,
+    checklist,
+    keyInformation: sanitizeLegacyKeyInformation(source.keyInformation),
+    status: boundedString(source.status, 200),
+    isArchived: source.isArchived === true,
+    createdAt: timestampToIso(source.createdAt),
+    lastUpdatedAt: timestampToIso(source.lastUpdatedAt),
+    accessExpiresAt: timestampToIso(source.accessExpiresAt)
+  };
+}
+
+export function createLegacyCustomerLookup({
+  getDatabase = () => getDefaultDatabase(process.env)
+} = {}) {
+  return async function lookupLegacyCustomer(normalizedReference, lastName) {
+    if (typeof normalizedReference !== 'string' || typeof lastName !== 'string') return null;
+    let database;
+    try {
+      database = await getDatabase();
+      const snapshot = await database.collection('customers')
+        .where('referenceNumber', '==', normalizedReference)
+        .where('lastName_lowercase', '==', lastName.trim().toLowerCase())
+        .limit(1)
+        .get();
+
+      if (snapshot.empty) return null;
+      const document = snapshot.docs[0];
+      return sanitizeLegacyCustomer(document.id, document.data());
+    } catch (error) {
+      if (error instanceof HttpError) throw error;
+      throw new HttpError(503, 'The package service is temporarily unavailable. Please try again shortly.', {
+        code: 'LEGACY_UNAVAILABLE',
+        cause: error
+      });
+    }
+  };
+}
+
+export const lookupLegacyCustomer = createLegacyCustomerLookup();

--- a/server/package-access-resolver.js
+++ b/server/package-access-resolver.js
@@ -1,0 +1,49 @@
+import { HttpError } from './http.js';
+import {
+  ACCESS_MESSAGES,
+  createPackagePortalClient,
+  normalizeLastName,
+  normalizePackageReference
+} from './package-portal.js';
+import { lookupLegacyCustomer } from './legacy-customer.js';
+
+export function createPackageAccessResolver({
+  portalClientFactory = () => createPackagePortalClient(),
+  legacyLookup = lookupLegacyCustomer
+} = {}) {
+  return async function resolvePackageAccess(rawReference, rawLastName) {
+    const reference = normalizePackageReference(rawReference);
+    const lastName = normalizeLastName(rawLastName);
+    if (!reference || !lastName) {
+      throw new HttpError(400, 'Reference number and last name are required in the expected format.', {
+        code: 'INVALID_ACCESS_INPUT'
+      });
+    }
+
+    const portalClient = portalClientFactory();
+    const ptResult = await portalClient.accessPackage(reference, lastName);
+    if (ptResult.found) {
+      return {
+        source: 'pt_portal',
+        reference,
+        token: ptResult.token,
+        customer: null
+      };
+    }
+
+    // Firestore is deliberately touched only after a valid JSON 404 from PT-Portal.
+    const customer = await legacyLookup(reference, lastName);
+    if (!customer) {
+      throw new HttpError(404, ACCESS_MESSAGES.invalid, { code: 'PACKAGE_NOT_FOUND' });
+    }
+
+    return {
+      source: 'legacy_firebase',
+      reference,
+      token: null,
+      customer
+    };
+  };
+}
+
+export const resolvePackageAccess = createPackageAccessResolver();

--- a/server/package-portal.js
+++ b/server/package-portal.js
@@ -1,0 +1,493 @@
+import { HttpError, sanitizeRetryAfter } from './http.js';
+
+export const PACKAGE_TOKEN_PATTERN = /^[A-Za-z0-9._~-]{8,512}$/;
+const PACKAGE_REFERENCE_PATTERN = /^(?:PT-)?([A-Z0-9]{6})$/i;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/;
+const DEFAULT_TIMEOUT_MS = 10_000;
+const MIN_TIMEOUT_MS = 1_000;
+const MAX_TIMEOUT_MS = 30_000;
+const ACCESS_RESPONSE_LIMIT_BYTES = 32 * 1024;
+const PACKAGE_RESPONSE_LIMIT_BYTES = 2 * 1024 * 1024;
+
+const ACCESS_MESSAGES = Object.freeze({
+  invalid: 'Package details do not match. Check the lead passenger surname and reference.',
+  expired: 'Your document access has expired. Contact your agent to renew access.',
+  throttled: 'Too many attempts. Please wait before trying again.',
+  unavailable: 'The package service is temporarily unavailable. Please try again shortly.'
+});
+
+const DATA_MESSAGES = Object.freeze({
+  invalid: 'Invalid package access token.',
+  unavailable: 'Package documents are not currently available. Contact your agent.',
+  expired: 'Your document access has expired. Contact your agent to renew access.',
+  throttled: 'Too many attempts. Please wait before trying again.',
+  service: 'The package service is temporarily unavailable. Please try again shortly.'
+});
+
+export function normalizePackageReference(rawValue) {
+  if (typeof rawValue !== 'string') return null;
+  const match = rawValue.trim().match(PACKAGE_REFERENCE_PATTERN);
+  return match ? `PT-${match[1].toUpperCase()}` : null;
+}
+
+export function normalizeLastName(rawValue) {
+  if (typeof rawValue !== 'string') return null;
+  const value = rawValue.trim();
+  if (!value || value.length > 120 || CONTROL_CHARACTER_PATTERN.test(value)) return null;
+  return value;
+}
+
+export function isValidPackageToken(rawValue) {
+  return typeof rawValue === 'string' && PACKAGE_TOKEN_PATTERN.test(rawValue);
+}
+
+export function requirePackageToken(rawValue) {
+  const value = typeof rawValue === 'string' ? rawValue.trim() : '';
+  if (!isValidPackageToken(value)) {
+    throw new HttpError(400, DATA_MESSAGES.invalid, { code: 'INVALID_TOKEN' });
+  }
+  return value;
+}
+
+export function parseRequestTimeout(rawValue) {
+  if (rawValue == null || rawValue === '') return DEFAULT_TIMEOUT_MS;
+  const parsed = Number(rawValue);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TIMEOUT_MS;
+  return Math.min(Math.max(Math.trunc(parsed), MIN_TIMEOUT_MS), MAX_TIMEOUT_MS);
+}
+
+export function resolvePtPortalBaseUrl(rawValue) {
+  if (typeof rawValue !== 'string' || !rawValue.trim() || rawValue.length > 2_048) {
+    throw new HttpError(503, ACCESS_MESSAGES.unavailable, { code: 'INVALID_BASE_URL' });
+  }
+
+  let url;
+  try {
+    url = new URL(rawValue.trim());
+  } catch (error) {
+    throw new HttpError(503, ACCESS_MESSAGES.unavailable, {
+      code: 'INVALID_BASE_URL',
+      cause: error
+    });
+  }
+
+  const isLocalHost = ['localhost', '127.0.0.1', '::1', '[::1]'].includes(url.hostname);
+  if (
+    !['http:', 'https:'].includes(url.protocol) ||
+    (url.protocol !== 'https:' && !isLocalHost) ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash
+  ) {
+    throw new HttpError(503, ACCESS_MESSAGES.unavailable, { code: 'INVALID_BASE_URL' });
+  }
+
+  url.pathname = `${url.pathname.replace(/\/+$/, '')}/`;
+  return url;
+}
+
+function isPlainObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function optionalString(value, maxLength = 2_000) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, maxLength) : null;
+}
+
+function optionalFiniteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+export function sanitizePublicUrl(value) {
+  if (typeof value !== 'string' || !value || value.length > 8_192) return null;
+  try {
+    const url = new URL(value);
+    const isLocalHost = ['localhost', '127.0.0.1', '::1', '[::1]'].includes(url.hostname);
+    if (
+      !['http:', 'https:'].includes(url.protocol) ||
+      (url.protocol !== 'https:' && !isLocalHost) ||
+      url.username ||
+      url.password
+    ) return null;
+    return url.toString();
+  } catch (_error) {
+    return null;
+  }
+}
+
+function isForbiddenPublicKey(key) {
+  const normalized = String(key).toLowerCase().replace(/[^a-z0-9]/g, '');
+  if (!normalized || ['__proto__', 'prototype', 'constructor'].includes(key)) return true;
+
+  return [
+    'internal',
+    'commission',
+    'margin',
+    'profit',
+    'employee',
+    'audit',
+    'riskflag',
+    'shareaccesscode',
+    'thirdpartyaccess',
+    'supplierallocation',
+    'storagebucket',
+    'bucketname',
+    'objectkey',
+    'storagekey',
+    'bookedcost',
+    'netcost',
+    'suppliercost',
+    'hiddenline',
+    'accesstoken',
+    'accesscode',
+    'sharecode',
+    'supplierprice',
+    'suppliernet',
+    'supplierid',
+    'providerid',
+    'driverid',
+    'customerid',
+    'reservationid',
+    'purchaseprice',
+    'buyprice',
+    'buyingprice',
+    'buyrate',
+    'netrate',
+    'wholesale',
+    'passengername',
+    'travellername',
+    'familymember'
+  ].some((fragment) => normalized.includes(fragment)) ||
+    normalized === 'token' ||
+    normalized.includes('cost');
+}
+
+export function sanitizeJsonValue(value, depth = 0) {
+  if (depth > 8) return null;
+  if (value == null || typeof value === 'boolean') return value;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value === 'string') return value.slice(0, 20_000);
+
+  if (Array.isArray(value)) {
+    return value.slice(0, 500).map((item) => sanitizeJsonValue(item, depth + 1));
+  }
+
+  if (!isPlainObject(value)) return null;
+  if (
+    value.customer_visible === false ||
+    value.is_customer_visible === false ||
+    value.visible_to_customer === false ||
+    value.is_visible === false ||
+    value.hidden === true ||
+    value.is_hidden === true
+  ) return null;
+
+  const output = {};
+  for (const [key, childValue] of Object.entries(value).slice(0, 200)) {
+    if (key.length > 100 || isForbiddenPublicKey(key)) continue;
+    const sanitized = sanitizeJsonValue(childValue, depth + 1);
+    if (sanitized !== undefined) output[key] = sanitized;
+  }
+  return output;
+}
+
+function sanitizeDocument(value) {
+  if (!isPlainObject(value)) return null;
+  if ('customer_visible' in value && value.customer_visible !== true) return null;
+  if (
+    'status' in value &&
+    (typeof value.status !== 'string' || value.status.trim().toLowerCase() !== 'released')
+  ) return null;
+
+  const category = optionalString(value.category, 80);
+  if (!category || category.toLowerCase().replace(/[^a-z0-9]/g, '') === 'traveldocuments') {
+    return null;
+  }
+
+  const id = ['string', 'number'].includes(typeof value.id)
+    ? optionalString(String(value.id), 200)
+    : null;
+  const fileName = optionalString(value.file_name, 500);
+  const title = optionalString(value.title, 500) || fileName;
+  const signedUrl = sanitizePublicUrl(value.signed_url);
+  const previewUrl = sanitizePublicUrl(value.preview_url);
+  if (!id || !title || (!signedUrl && !previewUrl)) return null;
+
+  return {
+    id,
+    category,
+    title,
+    file_name: fileName || title,
+    file_size: optionalFiniteNumber(value.file_size) ?? optionalString(value.file_size, 100),
+    file_type: optionalString(value.file_type, 200),
+    released_at: optionalString(value.released_at, 100),
+    public_notes: optionalString(value.public_notes, 10_000),
+    signed_url: signedUrl,
+    preview_url: previewUrl,
+    status: 'released',
+    customer_visible: true
+  };
+}
+
+function sanitizeChecklistItem(value, index) {
+  if (typeof value === 'string') {
+    const label = optionalString(value, 500);
+    return label ? { id: `checklist-${index + 1}`, label, status: '', completed: false } : null;
+  }
+  if (!isPlainObject(value)) return null;
+  if (
+    value.customer_visible === false ||
+    value.is_customer_visible === false ||
+    value.hidden === true ||
+    value.is_hidden === true
+  ) return null;
+
+  const label = optionalString(
+    value.customer_label ?? value.customerLabel ?? value.label ?? value.text ?? value.title,
+    500
+  );
+  if (!label) return null;
+  const idValue = ['string', 'number'].includes(typeof value.id)
+    ? String(value.id)
+    : `checklist-${index + 1}`;
+  return {
+    id: optionalString(idValue, 200),
+    label,
+    status: optionalString(value.status ?? value.state, 120),
+    completed: value.completed === true || value.is_complete === true || value.isComplete === true
+  };
+}
+
+export function sanitizePackagePayload(payload) {
+  if (!isPlainObject(payload) || !isPlainObject(payload.package) || !Array.isArray(payload.documents)) {
+    throw new HttpError(503, DATA_MESSAGES.service, { code: 'INVALID_UPSTREAM_PAYLOAD' });
+  }
+
+  const packageReference = normalizePackageReference(payload.package.package_reference);
+  const customerName = optionalString(payload.package.customer_name, 500);
+  if (!packageReference || !customerName) {
+    throw new HttpError(503, DATA_MESSAGES.service, { code: 'INVALID_UPSTREAM_PAYLOAD' });
+  }
+
+  const publicSummary = isPlainObject(payload.package.current_public_summary)
+    ? sanitizeJsonValue(payload.package.current_public_summary)
+    : {};
+  const packageData = {
+    id: optionalString(payload.package.id, 200),
+    package_reference: packageReference,
+    customer_name: customerName,
+    customer_email: optionalString(payload.package.customer_email, 500),
+    package_type: optionalString(payload.package.package_type, 200),
+    destination: optionalString(payload.package.destination, 500),
+    departure_date: optionalString(payload.package.departure_date, 100),
+    return_date: optionalString(payload.package.return_date, 100),
+    document_access_expires_at: optionalString(payload.package.document_access_expires_at, 100),
+    document_release_status: optionalString(payload.package.document_release_status, 100),
+    current_public_summary: publicSummary || {},
+    passport_status: optionalString(payload.package.passport_status, 100)
+  };
+
+  const documents = payload.documents
+    .slice(0, 500)
+    .map(sanitizeDocument)
+    .filter(Boolean);
+  const rawChecklist = Array.isArray(payload.checklist)
+    ? payload.checklist
+    : Array.isArray(payload.package.checklist)
+      ? payload.package.checklist
+      : [];
+  const checklist = rawChecklist
+    .slice(0, 200)
+    .map(sanitizeChecklistItem)
+    .filter(Boolean);
+
+  const signedUrlExpiresIn = optionalFiniteNumber(payload.signedUrlExpiresIn);
+  return {
+    package: packageData,
+    documents,
+    checklist,
+    releasedInvoice: isPlainObject(payload.releasedInvoice)
+      ? sanitizeJsonValue(payload.releasedInvoice)
+      : null,
+    transportVoucher: isPlainObject(payload.transportVoucher)
+      ? sanitizeJsonValue(payload.transportVoucher)
+      : null,
+    signedUrlExpiresIn: signedUrlExpiresIn && signedUrlExpiresIn > 0
+      ? Math.min(Math.trunc(signedUrlExpiresIn), 86_400)
+      : null
+  };
+}
+
+async function readBoundedText(response, maxBytes) {
+  const contentLength = Number(response.headers?.get?.('content-length'));
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    throw new HttpError(503, DATA_MESSAGES.service, { code: 'UPSTREAM_RESPONSE_TOO_LARGE' });
+  }
+
+  if (!response.body) return '';
+  if (typeof response.body.getReader !== 'function') {
+    const data = new Uint8Array(await response.arrayBuffer());
+    if (data.byteLength > maxBytes) {
+      throw new HttpError(503, DATA_MESSAGES.service, { code: 'UPSTREAM_RESPONSE_TOO_LARGE' });
+    }
+    return new TextDecoder().decode(data);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let totalBytes = 0;
+  let text = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        await reader.cancel();
+        throw new HttpError(503, DATA_MESSAGES.service, { code: 'UPSTREAM_RESPONSE_TOO_LARGE' });
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    return text;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function parseUpstreamJson(text) {
+  if (!text) return { valid: false, payload: null };
+  try {
+    const payload = JSON.parse(text);
+    return { valid: isPlainObject(payload), payload };
+  } catch (_error) {
+    return { valid: false, payload: null };
+  }
+}
+
+export function createPackagePortalClient({ fetchImpl = globalThis.fetch, env = process.env } = {}) {
+  if (typeof fetchImpl !== 'function') {
+    throw new HttpError(503, ACCESS_MESSAGES.unavailable, { code: 'FETCH_UNAVAILABLE' });
+  }
+
+  const requestJson = async (relativePath, init, maxBytes) => {
+    const baseUrl = resolvePtPortalBaseUrl(env.PT_PORTAL_BASE_URL);
+    const url = new URL(relativePath.replace(/^\/+/, ''), baseUrl);
+    const controller = new AbortController();
+    const timeout = parseRequestTimeout(env.PT_PORTAL_REQUEST_TIMEOUT_MS);
+    const timer = setTimeout(() => controller.abort(), timeout);
+
+    try {
+      const response = await fetchImpl(url, {
+        ...init,
+        redirect: 'error',
+        signal: controller.signal
+      });
+      const text = await readBoundedText(response, maxBytes);
+      const parsed = parseUpstreamJson(text);
+      return {
+        status: response.status,
+        ok: response.ok,
+        retryAfter: sanitizeRetryAfter(response.headers?.get?.('retry-after')),
+        jsonValid: parsed.valid,
+        payload: parsed.payload
+      };
+    } catch (error) {
+      if (error instanceof HttpError) throw error;
+      if (error?.name === 'AbortError' || controller.signal.aborted) {
+        throw new HttpError(504, ACCESS_MESSAGES.unavailable, {
+          code: 'UPSTREAM_TIMEOUT',
+          cause: error
+        });
+      }
+      throw new HttpError(503, ACCESS_MESSAGES.unavailable, {
+        code: 'UPSTREAM_UNAVAILABLE',
+        cause: error
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+
+  const accessPackage = async (reference, lastName) => {
+    const result = await requestJson('api/package-portal/access', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ reference, lastName })
+    }, ACCESS_RESPONSE_LIMIT_BYTES);
+
+    if (result.status === 200 && result.ok) {
+      if (!result.jsonValid || !isValidPackageToken(result.payload?.token)) {
+        throw new HttpError(503, ACCESS_MESSAGES.unavailable, { code: 'INVALID_UPSTREAM_TOKEN' });
+      }
+      return { found: true, token: result.payload.token };
+    }
+
+    if (result.status === 404) {
+      if (!result.jsonValid) {
+        throw new HttpError(503, ACCESS_MESSAGES.unavailable, { code: 'NON_JSON_UPSTREAM_404' });
+      }
+      return { found: false, token: null };
+    }
+
+    if (result.status === 400) {
+      throw new HttpError(400, ACCESS_MESSAGES.invalid, { code: 'UPSTREAM_VALIDATION' });
+    }
+    if (result.status === 410) {
+      throw new HttpError(410, ACCESS_MESSAGES.expired, { code: 'ACCESS_EXPIRED' });
+    }
+    if (result.status === 429) {
+      throw new HttpError(429, ACCESS_MESSAGES.throttled, {
+        code: 'ACCESS_THROTTLED',
+        retryAfter: result.retryAfter
+      });
+    }
+
+    throw new HttpError(503, ACCESS_MESSAGES.unavailable, { code: 'UPSTREAM_ACCESS_ERROR' });
+  };
+
+  const loadPackage = async (rawToken) => {
+    const token = requirePackageToken(rawToken);
+    const result = await requestJson(
+      `api/package-documents/${encodeURIComponent(token)}`,
+      { method: 'GET', headers: { Accept: 'application/json' } },
+      PACKAGE_RESPONSE_LIMIT_BYTES
+    );
+
+    if (result.status === 200 && result.ok) {
+      if (!result.jsonValid) {
+        throw new HttpError(503, DATA_MESSAGES.service, { code: 'INVALID_UPSTREAM_PAYLOAD' });
+      }
+      return sanitizePackagePayload(result.payload);
+    }
+    if (result.status === 400) {
+      throw new HttpError(400, DATA_MESSAGES.invalid, { code: 'INVALID_TOKEN' });
+    }
+    if (result.status === 404) {
+      throw new HttpError(404, DATA_MESSAGES.unavailable, { code: 'PACKAGE_UNAVAILABLE' });
+    }
+    if (result.status === 410) {
+      throw new HttpError(410, DATA_MESSAGES.expired, { code: 'ACCESS_EXPIRED' });
+    }
+    if (result.status === 429) {
+      throw new HttpError(429, DATA_MESSAGES.throttled, {
+        code: 'ACCESS_THROTTLED',
+        retryAfter: result.retryAfter
+      });
+    }
+    throw new HttpError(503, DATA_MESSAGES.service, { code: 'UPSTREAM_DATA_ERROR' });
+  };
+
+  return { accessPackage, loadPackage };
+}
+
+export { ACCESS_MESSAGES, DATA_MESSAGES };

--- a/server/package-session.js
+++ b/server/package-session.js
@@ -1,0 +1,168 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
+import { HttpError } from './http.js';
+import { isValidPackageToken } from './package-portal.js';
+
+export const PACKAGE_SESSION_COOKIE = '__Host-piyam_package_session';
+export const PACKAGE_SESSION_TTL_SECONDS = 60 * 60;
+const SESSION_VERSION = 'v1';
+const MINIMUM_SECRET_LENGTH = 32;
+const MAXIMUM_COOKIE_VALUE_LENGTH = 4_096;
+
+function normalizeSessionTtl(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return PACKAGE_SESSION_TTL_SECONDS;
+  return Math.min(Math.max(Math.trunc(parsed), 60), 86_400);
+}
+
+function getSessionKey(env = process.env) {
+  const secret = env.PACKAGE_PORTAL_SESSION_SECRET;
+  if (
+    typeof secret !== 'string' ||
+    secret.trim().length < MINIMUM_SECRET_LENGTH ||
+    Buffer.byteLength(secret, 'utf8') < MINIMUM_SECRET_LENGTH
+  ) return null;
+  return createHash('sha256')
+    .update('piyam-bookings-package-session-v1\0', 'utf8')
+    .update(secret, 'utf8')
+    .digest();
+}
+
+function toBase64Url(value) {
+  return Buffer.from(value).toString('base64url');
+}
+
+function fromBase64Url(value, maximumBytes) {
+  if (typeof value !== 'string' || !/^[A-Za-z0-9_-]+$/.test(value)) return null;
+  try {
+    const decoded = Buffer.from(value, 'base64url');
+    return decoded.length <= maximumBytes ? decoded : null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+export function isPackageSessionConfigured(env = process.env) {
+  return Boolean(getSessionKey(env));
+}
+
+export function encryptPackageSession(token, {
+  env = process.env,
+  now = Date.now(),
+  ttlSeconds = PACKAGE_SESSION_TTL_SECONDS
+} = {}) {
+  if (!isValidPackageToken(token)) {
+    throw new HttpError(400, 'Invalid package access token.', { code: 'INVALID_TOKEN' });
+  }
+
+  const key = getSessionKey(env);
+  if (!key) {
+    throw new HttpError(503, 'Secure package sessions are not configured.', {
+      code: 'SESSION_NOT_CONFIGURED'
+    });
+  }
+
+  const boundedTtl = normalizeSessionTtl(ttlSeconds);
+  const payload = Buffer.from(JSON.stringify({
+    v: 1,
+    token,
+    exp: now + boundedTtl * 1_000
+  }), 'utf8');
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  cipher.setAAD(Buffer.from(SESSION_VERSION, 'utf8'));
+  const encrypted = Buffer.concat([cipher.update(payload), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  return `${SESSION_VERSION}.${toBase64Url(iv)}.${toBase64Url(encrypted)}.${toBase64Url(tag)}`;
+}
+
+export function decryptPackageSession(value, {
+  env = process.env,
+  now = Date.now()
+} = {}) {
+  if (typeof value !== 'string' || value.length > MAXIMUM_COOKIE_VALUE_LENGTH) return null;
+  const key = getSessionKey(env);
+  if (!key) return null;
+
+  const parts = value.split('.');
+  if (parts.length !== 4 || parts[0] !== SESSION_VERSION) return null;
+  const iv = fromBase64Url(parts[1], 12);
+  const encrypted = fromBase64Url(parts[2], 2_048);
+  const tag = fromBase64Url(parts[3], 16);
+  if (!iv || iv.length !== 12 || !encrypted || !encrypted.length || !tag || tag.length !== 16) {
+    return null;
+  }
+
+  try {
+    const decipher = createDecipheriv('aes-256-gcm', key, iv);
+    decipher.setAAD(Buffer.from(SESSION_VERSION, 'utf8'));
+    decipher.setAuthTag(tag);
+    const plaintext = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+    if (plaintext.length > 2_048) return null;
+
+    const payload = JSON.parse(plaintext.toString('utf8'));
+    if (
+      payload?.v !== 1 ||
+      !isValidPackageToken(payload.token) ||
+      !Number.isFinite(payload.exp) ||
+      payload.exp <= now ||
+      payload.exp > now + (86_400 + 60) * 1_000
+    ) {
+      return null;
+    }
+    return { token: payload.token, expiresAt: payload.exp };
+  } catch (_error) {
+    return null;
+  }
+}
+
+export function parseCookies(headerValue) {
+  const cookies = Object.create(null);
+  if (typeof headerValue !== 'string' || headerValue.length > 16_384) return cookies;
+
+  for (const part of headerValue.split(';').slice(0, 100)) {
+    const separator = part.indexOf('=');
+    if (separator <= 0) continue;
+    const name = part.slice(0, separator).trim();
+    const value = part.slice(separator + 1).trim();
+    if (name && !Object.prototype.hasOwnProperty.call(cookies, name)) cookies[name] = value;
+  }
+  return cookies;
+}
+
+function appendSetCookie(res, cookie) {
+  const existing = res.getHeader?.('Set-Cookie');
+  if (!existing) {
+    res.setHeader('Set-Cookie', cookie);
+  } else if (Array.isArray(existing)) {
+    res.setHeader('Set-Cookie', [...existing, cookie]);
+  } else {
+    res.setHeader('Set-Cookie', [String(existing), cookie]);
+  }
+}
+
+export function setPackageSessionCookie(res, token, {
+  env = process.env,
+  ttlSeconds = PACKAGE_SESSION_TTL_SECONDS
+} = {}) {
+  if (!isPackageSessionConfigured(env)) return false;
+  const value = encryptPackageSession(token, { env, ttlSeconds });
+  const boundedTtl = normalizeSessionTtl(ttlSeconds);
+  appendSetCookie(
+    res,
+    `${PACKAGE_SESSION_COOKIE}=${value}; Path=/; Max-Age=${boundedTtl}; HttpOnly; Secure; SameSite=Lax`
+  );
+  return true;
+}
+
+export function clearPackageSessionCookie(res) {
+  appendSetCookie(
+    res,
+    `${PACKAGE_SESSION_COOKIE}=; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=Lax`
+  );
+}
+
+export function readPackageSession(req, { env = process.env } = {}) {
+  const cookies = parseCookies(req?.headers?.cookie);
+  return decryptPackageSession(cookies[PACKAGE_SESSION_COOKIE], { env });
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,20 +1,34 @@
-import React, { useState, useEffect } from 'react';
+import React, { lazy, Suspense, useEffect, useState } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
-import { onAuthStateChanged, signOut } from "firebase/auth";
-import { auth } from './firebase'; 
-import AgentLogin from './components/AgentLogin';
-import AgentDashboard from './components/AgentDashboard';
-import ClientPortal from './components/ClientPortal';
+
+const ClientPortal = lazy(() => import('./components/ClientPortal'));
+const AgentPortal = lazy(() => import('./components/AgentPortal'));
+
+function RouteLoading() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-100 dark:bg-gray-900">
+      <p className="text-gray-500">Loading portal…</p>
+    </div>
+  );
+}
 
 export default function App() {
-  const [user, setUser] = useState(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [theme, setTheme] = useState(localStorage.getItem('theme') || 'light');
+  const [theme, setTheme] = useState(() => {
+    try {
+      return localStorage.getItem('theme') || 'light';
+    } catch (_error) {
+      return 'light';
+    }
+  });
 
   const toggleTheme = () => {
     const newTheme = theme === 'light' ? 'dark' : 'light';
     setTheme(newTheme);
-    localStorage.setItem('theme', newTheme);
+    try {
+      localStorage.setItem('theme', newTheme);
+    } catch (_error) {
+      // Theme persistence is optional when browser storage is unavailable.
+    }
   };
 
   useEffect(() => {
@@ -25,26 +39,6 @@ export default function App() {
     }
   }, [theme]);
 
-  useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
-      setUser(user);
-      setIsLoading(false);
-    });
-    return () => unsubscribe();
-  }, []);
-
-  const handleLogout = () => {
-    signOut(auth).catch((error) => console.error("Sign out error:", error));
-  };
-
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center h-screen bg-gray-100 dark:bg-gray-900">
-        <p className="text-gray-500">Loading Portal...</p>
-      </div>
-    );
-  }
-
   return (
     <div className="relative">
         <button
@@ -54,11 +48,15 @@ export default function App() {
         >
             {theme === 'light' ? '🌙' : '☀️'}
         </button>
-        <Routes>
-            <Route path="/" element={<ClientPortal />} />
-            <Route path="/agent" element={user ? <AgentDashboard onLogout={handleLogout} /> : <AgentLogin />} />
-            <Route path="*" element={<Navigate to="/" />} />
-        </Routes>
+        <Suspense fallback={<RouteLoading />}>
+          <Routes>
+              <Route path="/" element={<ClientPortal />} />
+              <Route path="/documents" element={<ClientPortal />} />
+              <Route path="/package-documents/:token" element={<ClientPortal />} />
+              <Route path="/agent" element={<AgentPortal />} />
+              <Route path="*" element={<Navigate to="/" replace />} />
+          </Routes>
+        </Suspense>
     </div>
   );
 }

--- a/src/adapters/legacyPackageAdapter.js
+++ b/src/adapters/legacyPackageAdapter.js
@@ -1,0 +1,47 @@
+import { normalizeReleasedInvoice, normalizeTransportVoucher } from './portalReleaseAdapters.js';
+import { cleanText, isRecord, normalizeDocumentCategory, safeExternalUrl } from '../utils/packagePortal.js';
+
+function normalizeLegacyDocument(document, index) {
+  const record = isRecord(document) ? document : {};
+  const fileName = cleanText(record.name || record.fileName, 'document', 500);
+
+  return {
+    id: cleanText(record.id || record.name || record.fileName, `legacy-document-${index + 1}`, 200),
+    category: normalizeDocumentCategory(record.category),
+    title: cleanText(record.name || record.fileName, 'Document', 500),
+    file_name: fileName,
+    file_size: record.file_size ?? record.size ?? null,
+    file_type: cleanText(record.type, '', 200),
+    released_at: record.releasedAt || null,
+    public_notes: cleanText(record.publicNotes, '', 5000),
+    signed_url: safeExternalUrl(record.url),
+    preview_url: safeExternalUrl(record.url),
+    status: 'released',
+    customer_visible: true
+  };
+}
+
+/**
+ * Preserve the complete legacy customer contract for the existing editable
+ * Firebase dashboard while adding normalized aliases for a future shared shell.
+ * Raw `documents`, names, ids and timestamps are deliberately not overwritten.
+ */
+export function normalizeLegacyPackage(customer) {
+  const rawCustomer = isRecord(customer) ? customer : {};
+  const rawDocuments = Array.isArray(rawCustomer.documents) ? rawCustomer.documents : [];
+
+  return {
+    ...rawCustomer,
+    source: 'legacy_firebase',
+    reference: cleanText(rawCustomer.referenceNumber, '', 80),
+    customerName: `${cleanText(rawCustomer.firstName, '', 150)} ${cleanText(rawCustomer.lastName, '', 150)}`.trim(),
+    statusLabel: cleanText(rawCustomer.status, 'open', 120),
+    departureDate: rawCustomer.departureDate || rawCustomer.departure_date || null,
+    returnDate: rawCustomer.returnDate || rawCustomer.return_date || null,
+    accessExpiresAt: rawCustomer.accessExpiresAt || null,
+    publicSummary: isRecord(rawCustomer.publicSummary) ? rawCustomer.publicSummary : {},
+    portalDocuments: rawDocuments.map(normalizeLegacyDocument),
+    portalTransportVoucher: normalizeTransportVoucher(rawCustomer.transportVoucher),
+    portalReleasedInvoice: normalizeReleasedInvoice(rawCustomer.releasedInvoice)
+  };
+}

--- a/src/adapters/portalReleaseAdapters.js
+++ b/src/adapters/portalReleaseAdapters.js
@@ -1,0 +1,214 @@
+import {
+  cleanText,
+  firstValue,
+  isExplicitFalse,
+  isExplicitTrue,
+  isRecord,
+  safeExternalUrl
+} from '../utils/packagePortal.js';
+
+const BLOCKED_RELEASE_STATUSES = new Set([
+  'draft',
+  'hidden',
+  'internal',
+  'revoked',
+  'unreleased',
+  'void',
+  'cancelled',
+  'canceled'
+]);
+
+function isExplicitlyUnavailable(record) {
+  if (!isRecord(record)) return true;
+  if (isExplicitFalse(record.customer_visible) || isExplicitFalse(record.customerVisible)) return true;
+  if (isExplicitFalse(record.is_released) || isExplicitFalse(record.isReleased)) return true;
+  if (isExplicitTrue(record.hidden) || isExplicitTrue(record.internal_only) || isExplicitTrue(record.internalOnly)) return true;
+
+  const status = cleanText(
+    firstValue([record], ['release_status', 'releaseStatus', 'status'], ''),
+    '',
+    80
+  ).toLowerCase();
+
+  return BLOCKED_RELEASE_STATUSES.has(status);
+}
+
+function sourceList(record, nestedKeys) {
+  const nested = nestedKeys
+    .map(key => record?.[key])
+    .filter(isRecord);
+  return [...nested, record].filter(isRecord);
+}
+
+function normalizeInvoiceLine(line, index) {
+  if (!isRecord(line) || isExplicitlyUnavailable(line)) return null;
+  if (isExplicitTrue(line.hidden) || isExplicitFalse(line.customer_visible) || isExplicitFalse(line.customerVisible)) return null;
+
+  const sources = [line];
+  const description = cleanText(firstValue(sources, [
+    'customer_description',
+    'customerDescription',
+    'public_description',
+    'publicDescription',
+    'description',
+    'title',
+    'name'
+  ], ''), '', 500);
+
+  if (!description) return null;
+
+  return {
+    id: cleanText(firstValue(sources, ['id', 'line_id', 'lineId'], `line-${index + 1}`), `line-${index + 1}`, 120),
+    description,
+    quantity: firstValue(sources, ['quantity', 'qty'], null),
+    soldAmount: firstValue(sources, ['sold_amount', 'soldAmount', 'unit_sold_amount', 'unitSoldAmount', 'unit_price', 'unitPrice', 'price'], null),
+    lineTotal: firstValue(sources, ['line_total', 'lineTotal', 'sold_total', 'soldTotal', 'total', 'amount'], null)
+  };
+}
+
+/**
+ * Converts a released invoice payload into an explicit customer-safe whitelist.
+ * Supplier costs, commission, margin, internal notes and unknown fields are never copied.
+ */
+export function normalizeReleasedInvoice(rawInvoice) {
+  if (!isRecord(rawInvoice) || isExplicitlyUnavailable(rawInvoice)) return null;
+
+  const sources = sourceList(rawInvoice, ['snapshot', 'invoice_snapshot', 'invoiceSnapshot', 'data']);
+  const lineValue = firstValue(sources, ['lines', 'line_items', 'lineItems', 'items'], []);
+  const lines = Array.isArray(lineValue)
+    ? lineValue.map(normalizeInvoiceLine).filter(Boolean)
+    : [];
+
+  const invoice = {
+    invoiceNumber: cleanText(firstValue(sources, ['invoice_number', 'invoiceNumber', 'number', 'reference'], ''), '', 120),
+    version: cleanText(firstValue(sources, ['version', 'invoice_version', 'invoiceVersion'], ''), '', 80),
+    currency: cleanText(firstValue(sources, ['currency', 'currency_code', 'currencyCode'], 'GBP'), 'GBP', 3).toUpperCase(),
+    releasedAt: firstValue(sources, ['released_at', 'releasedAt', 'release_date', 'releaseDate'], null),
+    dueDate: firstValue(sources, ['due_date', 'dueDate'], null),
+    customerTerms: cleanText(firstValue(sources, ['customer_terms', 'customerTerms', 'public_terms', 'publicTerms', 'terms'], ''), '', 5000),
+    subtotal: firstValue(sources, ['subtotal', 'sold_subtotal', 'soldSubtotal'], null),
+    discount: firstValue(sources, ['discount_amount', 'discountAmount', 'discount'], null),
+    total: firstValue(sources, ['total', 'total_amount', 'totalAmount', 'sold_total', 'soldTotal'], null),
+    amountPaid: firstValue(sources, ['amount_paid', 'amountPaid', 'paid_amount', 'paidAmount'], null),
+    balanceDue: firstValue(sources, ['balance_due', 'balanceDue', 'outstanding_balance', 'outstandingBalance'], null),
+    lines
+  };
+
+  const hasCustomerContent = Boolean(
+    invoice.invoiceNumber || invoice.version || invoice.customerTerms || invoice.lines.length ||
+    [invoice.subtotal, invoice.discount, invoice.total, invoice.amountPaid, invoice.balanceDue].some(value => value !== null)
+  );
+
+  return hasCustomerContent ? invoice : null;
+}
+
+function normalizeJourneyDetails(rawDetails) {
+  if (rawDetails === null || rawDetails === undefined) return null;
+  if (!isRecord(rawDetails)) {
+    const summary = cleanText(rawDetails, '', 1000);
+    return summary ? { summary } : null;
+  }
+
+  const sources = [rawDetails];
+  const details = {
+    summary: cleanText(firstValue(sources, ['summary', 'description', 'details'], ''), '', 1000),
+    date: firstValue(sources, ['date', 'travel_date', 'travelDate'], null),
+    time: cleanText(firstValue(sources, ['time', 'pickup_time', 'pickupTime'], ''), '', 80),
+    flightNumber: cleanText(firstValue(sources, ['flight_number', 'flightNumber', 'flight'], ''), '', 100),
+    airport: cleanText(firstValue(sources, ['airport', 'airport_name', 'airportName'], ''), '', 200),
+    terminal: cleanText(firstValue(sources, ['terminal'], ''), '', 100),
+    location: cleanText(firstValue(sources, ['location', 'pickup_location', 'pickupLocation'], ''), '', 300)
+  };
+
+  return Object.values(details).some(Boolean) ? details : null;
+}
+
+function normalizeContact(rawContact, fallbackSources = [], kind = 'generic') {
+  const sources = [rawContact, ...fallbackSources].filter(isRecord);
+  if (!sources.length) return null;
+
+  const nameKeys = kind === 'driver'
+    ? ['name', 'driver_name', 'driverName', 'contact_name', 'contactName']
+    : kind === 'provider'
+      ? ['name', 'company', 'provider_name', 'providerName', 'contact_name', 'contactName']
+      : ['name', 'contact_name', 'contactName', 'company'];
+  const phoneKeys = kind === 'driver'
+    ? ['phone', 'telephone', 'driver_contact', 'driverContact', 'contact_number', 'contactNumber', 'contact']
+    : kind === 'provider'
+      ? ['phone', 'telephone', 'provider_contact', 'providerContact', 'contact_number', 'contactNumber', 'contact']
+      : ['phone', 'telephone', 'contact_number', 'contactNumber', 'contact'];
+
+  const contact = {
+    name: cleanText(firstValue(sources, nameKeys, ''), '', 200),
+    phone: cleanText(firstValue(sources, phoneKeys, ''), '', 120),
+    email: cleanText(firstValue(sources, ['email'], ''), '', 254),
+    whatsApp: cleanText(firstValue(sources, ['whatsapp', 'whats_app', 'whatsApp'], ''), '', 120)
+  };
+
+  return Object.values(contact).some(Boolean) ? contact : null;
+}
+
+function normalizeRoute(route, index) {
+  if (!isRecord(route) || isExplicitlyUnavailable(route)) return null;
+  const sources = [route];
+  const providerRecord = firstValue(sources, ['provider', 'transport_provider', 'transportProvider'], null);
+  const driverRecord = firstValue(sources, ['driver'], null);
+
+  const normalized = {
+    id: cleanText(firstValue(sources, ['id', 'route_id', 'routeId'], `route-${index + 1}`), `route-${index + 1}`, 120),
+    label: cleanText(firstValue(sources, ['public_label', 'publicLabel', 'label', 'title', 'route_name', 'routeName'], `Route ${index + 1}`), `Route ${index + 1}`, 300),
+    from: cleanText(firstValue(sources, ['from', 'origin', 'pickup_location', 'pickupLocation'], ''), '', 300),
+    to: cleanText(firstValue(sources, ['to', 'destination', 'dropoff_location', 'dropoffLocation'], ''), '', 300),
+    date: firstValue(sources, ['date', 'travel_date', 'travelDate'], null),
+    time: cleanText(firstValue(sources, ['time', 'pickup_time', 'pickupTime'], ''), '', 80),
+    vehicleType: cleanText(firstValue(sources, ['vehicle_type', 'vehicleType', 'vehicle'], ''), '', 200),
+    publicNotes: cleanText(firstValue(sources, ['public_notes', 'publicNotes', 'customer_notes', 'customerNotes'], ''), '', 2000),
+    provider: normalizeContact(providerRecord, sources, 'provider'),
+    driver: normalizeContact(driverRecord, sources, 'driver')
+  };
+
+  const hasRouteContent = normalized.from || normalized.to || normalized.date || normalized.time ||
+    normalized.vehicleType || normalized.publicNotes || normalized.provider || normalized.driver;
+
+  return hasRouteContent ? normalized : null;
+}
+
+/**
+ * Converts a released transport voucher into a customer-safe whitelist.
+ * Route costs, supplier allocations and any unrecognised fields are never copied.
+ */
+export function normalizeTransportVoucher(rawVoucher) {
+  if (!isRecord(rawVoucher) || isExplicitlyUnavailable(rawVoucher)) return null;
+
+  const sources = sourceList(rawVoucher, ['voucher_data', 'voucherData', 'snapshot', 'data']);
+  const routeValue = firstValue(sources, ['routes', 'route_timeline', 'routeTimeline', 'timeline', 'segments', 'journeys'], []);
+  const routes = Array.isArray(routeValue)
+    ? routeValue.map(normalizeRoute).filter(Boolean)
+    : [];
+  const providerRecord = firstValue(sources, ['provider', 'transport_provider', 'transportProvider'], null);
+  const driverRecord = firstValue(sources, ['driver'], null);
+  const documentRecord = firstValue(sources, ['document', 'voucher_document', 'voucherDocument'], null);
+  const urlSources = [documentRecord, ...sources].filter(isRecord);
+
+  const voucher = {
+    voucherNumber: cleanText(firstValue(sources, ['voucher_number', 'voucherNumber', 'number', 'reference'], ''), '', 120),
+    version: cleanText(firstValue(sources, ['version', 'voucher_version', 'voucherVersion'], ''), '', 80),
+    releasedAt: firstValue(sources, ['released_at', 'releasedAt', 'release_date', 'releaseDate'], null),
+    publicNotes: cleanText(firstValue(sources, ['public_notes', 'publicNotes', 'customer_notes', 'customerNotes'], ''), '', 5000),
+    arrival: normalizeJourneyDetails(firstValue(sources, ['arrival', 'arrival_details', 'arrivalDetails'], null)),
+    departure: normalizeJourneyDetails(firstValue(sources, ['departure', 'departure_details', 'departureDetails'], null)),
+    routes,
+    provider: normalizeContact(providerRecord, sources, 'provider'),
+    driver: normalizeContact(driverRecord, sources, 'driver'),
+    previewUrl: safeExternalUrl(firstValue(urlSources, ['preview_url', 'previewUrl', 'view_url', 'viewUrl'], null)),
+    downloadUrl: safeExternalUrl(firstValue(urlSources, ['signed_url', 'signedUrl', 'download_url', 'downloadUrl'], null)),
+    fileName: cleanText(firstValue(urlSources, ['file_name', 'fileName'], 'transport-voucher'), 'transport-voucher', 300)
+  };
+
+  const hasCustomerContent = Boolean(
+    voucher.voucherNumber || voucher.version || voucher.publicNotes || voucher.arrival || voucher.departure ||
+    voucher.routes.length || voucher.provider || voucher.driver || voucher.previewUrl || voucher.downloadUrl
+  );
+
+  return hasCustomerContent ? voucher : null;
+}

--- a/src/adapters/ptPortalPackageAdapter.js
+++ b/src/adapters/ptPortalPackageAdapter.js
@@ -1,0 +1,134 @@
+import { normalizeReleasedInvoice, normalizeTransportVoucher } from './portalReleaseAdapters.js';
+import {
+  cleanText,
+  isExplicitFalse,
+  isExplicitTrue,
+  isRecord,
+  isTravelDocumentsCategory,
+  normalizeDocumentCategory,
+  safeExternalUrl
+} from '../utils/packagePortal.js';
+
+function isReleasedCustomerDocument(document) {
+  if (!isRecord(document)) return false;
+  if (isTravelDocumentsCategory(document.category)) return false;
+
+  // The PT endpoint already filters documents. These redundant fields are optional,
+  // but an explicit hidden/non-released value must still fail closed.
+  if (isExplicitFalse(document.customer_visible) || isExplicitFalse(document.customerVisible)) return false;
+  if (isExplicitTrue(document.hidden) || isExplicitTrue(document.internal_only) || isExplicitTrue(document.internalOnly)) return false;
+
+  const status = cleanText(document.status, '', 80).toLowerCase();
+  if (status && status !== 'released') return false;
+  return true;
+}
+
+function normalizeDocument(document, index) {
+  const title = cleanText(document.title || document.file_name, 'Document', 500);
+  const fileName = cleanText(document.file_name || document.title, 'document', 500);
+
+  return {
+    id: cleanText(document.id || document.file_name || document.title, `document-${index + 1}`, 200),
+    category: normalizeDocumentCategory(document.category),
+    title,
+    file_name: fileName,
+    file_size: document.file_size ?? null,
+    file_type: cleanText(document.file_type, '', 200),
+    released_at: document.released_at || null,
+    public_notes: cleanText(document.public_notes, '', 5000),
+    signed_url: safeExternalUrl(document.signed_url),
+    preview_url: safeExternalUrl(document.preview_url),
+    status: 'released',
+    customer_visible: true
+  };
+}
+
+function normalizePublicSummary(summary) {
+  if (!isRecord(summary)) return {};
+
+  const blockedFragments = [
+    'internal', 'supplier', 'cost', 'commission', 'margin', 'profit', 'employee',
+    'audit', 'risk', 'shareaccess', 'storage', 'objectkey', 'token'
+  ];
+
+  // The object is already designated public by PT-Portal. Keep only scalar values
+  // so nested operational records can never be passed to a rendering component.
+  return Object.entries(summary).reduce((safeSummary, [key, value]) => {
+    if (!/^[A-Za-z0-9_-]{1,80}$/.test(key)) return safeSummary;
+    if (['__proto__', 'prototype', 'constructor'].includes(key)) return safeSummary;
+    const normalizedKey = key.toLowerCase().replace(/[^a-z0-9]/g, '');
+    if (blockedFragments.some((fragment) => normalizedKey.includes(fragment))) return safeSummary;
+    if (!['string', 'number', 'boolean'].includes(typeof value)) return safeSummary;
+    safeSummary[key] = typeof value === 'string' ? cleanText(value, '', 2000) : value;
+    return safeSummary;
+  }, {});
+}
+
+function normalizeChecklist(rawChecklist, passportStatus) {
+  const checklist = Array.isArray(rawChecklist)
+    ? rawChecklist.map((item, index) => {
+      if (!isRecord(item)) {
+        const label = cleanText(item, '', 500);
+        return label ? { id: `checklist-${index + 1}`, label, status: '', completed: false } : null;
+      }
+      const label = cleanText(item.customer_label || item.customerLabel || item.label || item.text || item.title, '', 500);
+      if (!label) return null;
+
+      const status = cleanText(item.status || item.state, '', 120);
+      const normalizedStatus = status.toLowerCase();
+      const completed = item.completed === true || item.is_complete === true || item.isComplete === true ||
+        ['ready', 'complete', 'completed', 'done', 'approved'].includes(normalizedStatus);
+
+      return {
+        id: cleanText(item.id, `checklist-${index + 1}`, 160),
+        label,
+        status,
+        completed
+      };
+    }).filter(Boolean)
+    : [];
+
+  const safePassportStatus = cleanText(passportStatus, '', 120);
+  if (safePassportStatus && !checklist.some(item => /passport/i.test(item.label))) {
+    checklist.push({
+      id: 'passport-status',
+      label: 'Passport status',
+      status: safePassportStatus,
+      completed: ['ready', 'complete', 'completed', 'approved'].includes(safePassportStatus.toLowerCase())
+    });
+  }
+
+  return checklist;
+}
+
+/** Convert the public PT package response to the normalized customer view model. */
+export function normalizePtPortalPackage(apiPayload) {
+  const payload = isRecord(apiPayload) ? apiPayload : {};
+  const packageData = isRecord(payload.package) ? payload.package : {};
+  const documents = Array.isArray(payload.documents) ? payload.documents : [];
+  const expiresIn = Number(payload.signedUrlExpiresIn);
+  const rawChecklist = Array.isArray(payload.checklist) ? payload.checklist : packageData.checklist;
+
+  return {
+    source: 'pt_portal',
+    reference: cleanText(packageData.package_reference || packageData.reference, 'PT-UNKNOWN', 80),
+    customerName: cleanText(packageData.customer_name, 'Customer', 300),
+    packageType: cleanText(packageData.package_type, '', 120),
+    destination: cleanText(packageData.destination, '', 300),
+    departureDate: packageData.departure_date || null,
+    returnDate: packageData.return_date || null,
+    accessExpiresAt: packageData.document_access_expires_at || null,
+    statusLabel: cleanText(packageData.document_release_status || packageData.status, 'open', 120),
+    publicSummary: normalizePublicSummary(packageData.current_public_summary),
+    documents: documents.filter(isReleasedCustomerDocument).map(normalizeDocument),
+    transportVoucher: normalizeTransportVoucher(payload.transportVoucher || payload.transport_voucher),
+    releasedInvoice: normalizeReleasedInvoice(payload.releasedInvoice || payload.released_invoice),
+    checklist: normalizeChecklist(rawChecklist, packageData.passport_status || packageData.passportStatus),
+    keyInformation: {
+      customerEmail: cleanText(packageData.customer_email, '', 254),
+      customerName: cleanText(packageData.customer_name, 'Customer', 300)
+    },
+    signedUrlExpiresIn: Number.isFinite(expiresIn) && expiresIn > 0 ? Math.floor(expiresIn) : null,
+    loadedAt: new Date().toISOString()
+  };
+}

--- a/src/components/AgentDashboard.jsx
+++ b/src/components/AgentDashboard.jsx
@@ -357,7 +357,7 @@ export default function AgentDashboard({ onLogout }) {
             <div className="flex flex-col md:flex-row justify-between items-center mb-6 gap-4">
                 <div><h1 className="text-3xl font-bold text-gray-800">Customer Folders</h1><p className="text-gray-500 mt-1">Manage all your client travel packages.</p></div>
                 <div className="flex gap-4">
-                    <button onClick={() => setIsCreateModalOpen(true)} className="flex items-center justify-center bg-red-800 text-white font-semibold py-2 px-4 rounded-lg shadow-md hover:bg-red-700 transition-colors"><PlusIcon />Create New Folder</button>
+                    <button onClick={() => setIsCreateModalOpen(true)} className="flex items-center justify-center bg-red-800 text-white font-semibold py-2 px-4 rounded-lg shadow-md hover:bg-red-700 transition-colors"><PlusIcon />Create Legacy Folder</button>
                     <button onClick={onLogout} className="flex items-center justify-center bg-gray-600 text-white font-semibold py-2 px-4 rounded-lg shadow-md hover:bg-gray-500 transition-colors"><LogOutIcon />Sign Out</button>
                 </div>
             </div>
@@ -421,6 +421,9 @@ export default function AgentDashboard({ onLogout }) {
     return (
         <div className="bg-gray-100 min-h-screen p-4 md:p-8">
             <input type="file" ref={fileInputRef} onChange={handleFileChange} className="hidden" accept=".pdf,.jpg" multiple />
+            <div className="mb-4 rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm font-semibold text-amber-950" role="note">
+                Legacy package folders only. Create and manage new packages in PT-Portal.
+            </div>
             {selectedCustomer ? renderCustomerFolder() : renderDashboard()}
             <CreateFolderModal isOpen={isCreateModalOpen} onClose={() => setIsCreateModalOpen(false)} handleCreateCustomer={handleCreateCustomer} newCustomerFirstName={newCustomerFirstName} setNewCustomerFirstName={setNewCustomerFirstName} newCustomerLastName={newCustomerLastName} setNewCustomerLastName={setNewCustomerLastName} newPackageType={newPackageType} setNewPackageType={setNewPackageType} newDestination={newDestination} setNewDestination={setNewDestination} newCustomerRef={newCustomerRef} />
             <VoucherModal isOpen={isVoucherModalOpen} onClose={() => setIsVoucherModalOpen(false)} customer={selectedCustomer} handleCopy={handleCopy} copySuccess={copySuccess} />

--- a/src/components/AgentPortal.jsx
+++ b/src/components/AgentPortal.jsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import { onAuthStateChanged, signOut } from 'firebase/auth';
+import { auth } from '../firebase';
+import AgentDashboard from './AgentDashboard';
+import AgentLogin from './AgentLogin';
+
+export default function AgentPortal() {
+  const [user, setUser] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(
+      auth,
+      (nextUser) => {
+        setUser(nextUser);
+        setIsLoading(false);
+      },
+      (error) => {
+        console.error('Agent authentication state error:', error);
+        setIsLoading(false);
+      }
+    );
+
+    return unsubscribe;
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-100 dark:bg-gray-900">
+        <p className="text-gray-500">Loading agent portal…</p>
+      </div>
+    );
+  }
+
+  const handleLogout = async () => {
+    try {
+      await signOut(auth);
+    } catch (error) {
+      console.error('Agent sign out error:', error);
+    }
+  };
+
+  return user ? <AgentDashboard onLogout={handleLogout} /> : <AgentLogin />;
+}

--- a/src/components/ClientPortal.jsx
+++ b/src/components/ClientPortal.jsx
@@ -1,207 +1,489 @@
-import React, { useState, useEffect } from 'react';
-import { db } from '../firebase';
-import { doc, updateDoc, serverTimestamp } from "firebase/firestore";
-import { piyamTravelLogoBase64, fileCategories } from '../data';
-import { UserIcon, PhoneIcon, MailIcon, SimCardIcon, GlobeIcon, FileIcon, DownloadIcon, InfoIcon, PreviewIcon, XIcon } from './Icons';
+import React, {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { normalizePtPortalPackage } from '../adapters/ptPortalPackageAdapter';
+import {
+  loadPackageData,
+  logoutPackageSession
+} from '../services/packagePortalApi';
+import { getPackageErrorMessage } from '../services/packageErrorResolver';
+import PackageDocumentPreview from './portal/PackageDocumentPreview';
+import PackageDocuments from './portal/PackageDocuments';
+import PackageErrorState from './portal/PackageErrorState';
+import PackageHeader from './portal/PackageHeader';
+import PackageInvoice from './portal/PackageInvoice';
+import PackageLogin from './portal/PackageLogin';
+import PackageOverview from './portal/PackageOverview';
+import PackageTransportVoucher from './portal/PackageTransportVoucher';
 
-const PiyamTravelLogo = () => ( <img src={piyamTravelLogoBase64} alt="Piyam Travel Logo"/> );
+const LegacyClientDashboard = lazy(() => import('./legacy/LegacyClientDashboard'));
+const SIGNED_LINK_REFRESH_LEEWAY_MS = 60_000;
 
-const ClientLoginPage = ({ onLogin, setIsLoading }) => {
-    const [refNumber, setRefNumber] = useState('');
-    const [lastName, setLastName] = useState('');
-    const [error, setError] = useState('');
+function LoadingPanel({ message = 'Loading your package…' }) {
+  return (
+    <div className="rounded-2xl bg-white p-8 text-center shadow-xl dark:bg-gray-800" role="status" aria-live="polite">
+      <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-red-800" aria-hidden="true" />
+      <p className="text-gray-600 dark:text-gray-300">{message}</p>
+    </div>
+  );
+}
 
-    const handleSubmit = async (e) => {
-        e.preventDefault();
-        setError('');
-        setIsLoading(true);
+function signedLinksNeedRefresh(customer, now = Date.now()) {
+  const lifetimeSeconds = Number(customer?.signedUrlExpiresIn);
+  const loadedAt = Date.parse(customer?.loadedAt || '');
+  if (!Number.isFinite(lifetimeSeconds) || lifetimeSeconds <= 0 || !Number.isFinite(loadedAt)) return false;
+  const lifetimeMs = lifetimeSeconds * 1000;
+  const leeway = Math.min(SIGNED_LINK_REFRESH_LEEWAY_MS, Math.max(1_000, lifetimeMs * 0.1));
+  return now >= loadedAt + lifetimeMs - leeway;
+}
 
-        try {
-            const response = await fetch('/api/lookup-customer', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ referenceNumber: refNumber, lastName }),
-            });
-            const data = await response.json();
-            if (!response.ok) { throw new Error(data.error || 'Customer not found.'); }
-            onLogin(data);
-        } catch (err) {
-            console.error("Login error:", err);
-            setError(err.message || 'An error occurred. Please try again.');
-        } finally {
-            setIsLoading(false);
-        }
-    };
+function findDocument(customer, documentId) {
+  return customer?.documents?.find((document) => document.id === documentId) || null;
+}
 
-    return (
-        <div className="bg-white rounded-2xl shadow-xl overflow-hidden border-t-4 border-red-800">
-            <div className="p-8">
-                <div className="flex justify-center mb-6"><PiyamTravelLogo /></div>
-                <h1 className="text-2xl font-bold text-center text-gray-800 dark:text-gray-200 mb-2">Client Document Portal</h1>
-                <p className="text-gray-500 text-center mb-8">Access your travel documents securely.</p>
-                <form className="space-y-6" onSubmit={handleSubmit}>
-                    <div>
-                        <label htmlFor="refNumber" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Reference Number</label>
-                        <div className="mt-1 flex items-center">
-                            <span className="inline-flex items-center px-3 rounded-l-md border border-r-0 border-gray-300 bg-gray-50 text-gray-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-400">PT-</span>
-                            <input type="text" id="refNumber" value={refNumber} onChange={(e) => setRefNumber(e.target.value.toUpperCase())} placeholder="6P7GC2" className="flex-1 block w-full rounded-none rounded-r-lg p-2 border border-gray-300 focus:border-red-500 focus:ring-red-500 sm:text-sm dark:bg-gray-900 dark:border-gray-600" required />
-                        </div>
-                    </div>
-                    <div>
-                        <label htmlFor="lastName" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Last Name</label>
-                        <div className="mt-1 relative">
-                            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><UserIcon className="h-5 w-5 text-gray-400" /></div>
-                            <input type="text" id="lastName" value={lastName} onChange={(e) => setLastName(e.target.value)} placeholder="Your last name" className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-red-800 focus:border-red-800 dark:bg-gray-900 dark:border-gray-600" required />
-                        </div>
-                    </div>
-                    {error && <p className="text-sm text-red-600 text-center">{error}</p>}
-                    <div>
-                         <button type="submit" className="w-full flex justify-center py-3 px-4 border border-transparent rounded-lg shadow-sm text-sm font-medium text-white bg-red-800 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-colors">Access Documents</button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    );
-};
+function triggerDownload(documentToDownload) {
+  if (!documentToDownload?.signed_url) throw new Error('This secure download is unavailable.');
 
-const ClientDashboard = ({ customer, onLogout, onCustomerUpdate }) => {
-    const [previewFile, setPreviewFile] = useState(null);
-    const [isChecklistVisible, setIsChecklistVisible] = useState(true);
-    const [localSim, setLocalSim] = useState(customer.keyInformation?.customerSim || '');
-    const [localEmail, setLocalEmail] = useState(customer.keyInformation?.customerEmail || '');
+  const anchor = document.createElement('a');
+  anchor.href = documentToDownload.signed_url;
+  anchor.download = documentToDownload.file_name || documentToDownload.title || 'document';
+  anchor.target = '_blank';
+  anchor.rel = 'noopener noreferrer';
+  anchor.referrerPolicy = 'no-referrer';
+  anchor.style.display = 'none';
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+}
 
-    useEffect(() => {
-        setLocalSim(customer.keyInformation?.customerSim || '');
-        setLocalEmail(customer.keyInformation?.customerEmail || '');
-    }, [customer]);
+function openSecureTab(url, existingWindow = null) {
+  if (!url) throw new Error('This secure preview is unavailable.');
 
-    const handleSaveContactInfo = async () => {
-        const newKeyInfo = {
-            ...customer.keyInformation,
-            customerSim: localSim,
-            customerEmail: localEmail,
-            isEmailLocked: true
-        };
-        const customerDocRef = doc(db, "customers", customer.id);
-        try {
-            await updateDoc(customerDocRef, { keyInformation: newKeyInfo, lastUpdatedAt: serverTimestamp() });
-            onCustomerUpdate({ ...customer, keyInformation: newKeyInfo, lastUpdatedAt: new Date().toISOString() });
-            alert("Your contact information has been saved.");
-        } catch (error) {
-            console.error("Error updating contact info:", error);
-            alert("Could not save your information. Please try again.");
-        }
-    };
+  if (existingWindow && !existingWindow.closed) {
+    existingWindow.opener = null;
+    existingWindow.location.replace(url);
+    return;
+  }
 
-    const visibleCategories = fileCategories.filter(category =>
-        customer.documents && customer.documents.some(doc => doc.category === category.name)
-    );
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.target = '_blank';
+  anchor.rel = 'noopener noreferrer';
+  anchor.referrerPolicy = 'no-referrer';
+  anchor.style.display = 'none';
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+}
 
-    const getExpiryDate = () => {
-        const dateToUse = customer.accessExpiresAt || customer.createdAt;
-        if (!dateToUse) return 'N/A';
-        const expiryBaseDate = new Date(dateToUse);
-        if (!customer.accessExpiresAt) {
-            expiryBaseDate.setMonth(expiryBaseDate.getMonth() + 10);
-        }
-        return expiryBaseDate.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
-    };
+function PtPortalDashboard({ customer, isRefreshing, refreshMessage, onLogout, onRefreshPackage }) {
+  const [activeTab, setActiveTab] = useState('overview');
+  const [previewDocument, setPreviewDocument] = useState(null);
+  const [actionMessage, setActionMessage] = useState('');
 
-    const getLastUpdatedDate = () => {
-        if (!customer.lastUpdatedAt) return 'Not available';
-        return new Date(customer.lastUpdatedAt).toLocaleString('en-GB');
+  const tabs = useMemo(() => {
+    const availableTabs = [
+      { id: 'overview', label: 'Overview' },
+      { id: 'documents', label: 'Documents' }
+    ];
+    if (customer.transportVoucher) availableTabs.push({ id: 'transport', label: 'Transport' });
+    if (customer.releasedInvoice) availableTabs.push({ id: 'invoice', label: 'Invoice' });
+    return availableTabs;
+  }, [customer.releasedInvoice, customer.transportVoucher]);
+
+  useEffect(() => {
+    if (!tabs.some((tab) => tab.id === activeTab)) setActiveTab('overview');
+  }, [activeTab, tabs]);
+
+  const handleTabKeyDown = useCallback((event, currentIndex) => {
+    let nextIndex = currentIndex;
+
+    if (event.key === 'ArrowRight') {
+      nextIndex = (currentIndex + 1) % tabs.length;
+    } else if (event.key === 'ArrowLeft') {
+      nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+    } else if (event.key === 'Home') {
+      nextIndex = 0;
+    } else if (event.key === 'End') {
+      nextIndex = tabs.length - 1;
+    } else {
+      return;
     }
 
-    const keyInfo = customer.keyInformation || {};
-    const checklist = customer.checklist || [];
-    const isEmailEditable = !keyInfo.isEmailLocked || !keyInfo.customerEmail;
+    event.preventDefault();
+    const nextTab = tabs[nextIndex];
+    setActiveTab(nextTab.id);
+    window.requestAnimationFrame(() => {
+      document.getElementById(`package-tab-${nextTab.id}`)?.focus();
+    });
+  }, [tabs]);
 
-    const handleChecklistItemToggle = async (itemId) => {
-        const updatedChecklist = checklist.map(item =>
-            item.id === itemId ? { ...item, completed: !item.completed } : item
-        );
-        const customerDocRef = doc(db, "customers", customer.id);
-        try {
-            await updateDoc(customerDocRef, { checklist: updatedChecklist });
-            onCustomerUpdate({ ...customer, checklist: updatedChecklist });
-        } catch (error) {
-            console.error("Error updating checklist:", error);
-        }
-    };
+  const refreshDocument = useCallback(async (originalDocument, { force = false } = {}) => {
+    const refreshedPackage = await onRefreshPackage({ force });
+    const refreshedDocument = findDocument(refreshedPackage, originalDocument.id);
+    if (!refreshedDocument) {
+      throw new Error('This document is no longer available. Refresh the package to see current releases.');
+    }
+    return refreshedDocument;
+  }, [onRefreshPackage]);
 
-    return (
-        <>
-            <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-6 md:p-8 w-full">
-                <div className="flex flex-col md:flex-row justify-between items-start mb-8 gap-4 border-b border-gray-200 dark:border-gray-700 pb-6">
-                    <div>
-                        <p className="text-gray-500 font-mono text-sm">Reference: {customer.referenceNumber}</p>
-                        <h1 className="text-3xl md:text-4xl font-bold text-gray-800 dark:text-white mt-1">Welcome, {customer.firstName} {customer.lastName}</h1>
-                        <p className="text-gray-600 dark:text-gray-300 mt-2 text-lg font-semibold">{customer.packageType} to {customer.destination}</p>
-                    </div>
-                    <div className="flex flex-col items-start md:items-end gap-3 w-full md:w-auto">
-                        {customer.status === 'Completed' && <span className="text-base font-bold text-green-800 bg-green-200 px-4 py-2 rounded-full dark:bg-green-900 dark:text-green-300">Package Completed</span>}
-                        <button onClick={onLogout} className="w-full md:w-auto bg-gray-200 text-gray-800 font-semibold py-2 px-4 rounded-lg hover:bg-gray-300 transition-colors dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600">Log Out</button>
-                    </div>
-                </div>
+  const handleDownload = useCallback(async (documentToDownload) => {
+    setActionMessage('');
+    try {
+      if (!signedLinksNeedRefresh(customer)) {
+        triggerDownload(documentToDownload);
+        return;
+      }
 
-                {/* --- Key Information Card (Maroon Theme) --- */}
-                <div className="mb-8 p-4 bg-red-800 text-white rounded-lg">
-                    <h3 className="text-lg font-bold mb-4">Key Information</h3>
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4 text-sm">
-                        <div className="flex items-start gap-3"><UserIcon className="h-5 w-5 mt-1 opacity-75"/><div><p className="font-semibold">Your Agent</p><p className="opacity-90">{keyInfo.agentName}</p><p className="opacity-90">{keyInfo.agentContact}</p><p className="text-xs italic mt-1 opacity-75">{keyInfo.whatsAppNotes}</p></div></div>
-                        <div className="flex items-start gap-3"><GlobeIcon className="h-5 w-5 mt-1 opacity-75"/><div><p className="font-semibold">Ground Transport Manager</p><p className="opacity-90">{keyInfo.groundTransportManager}</p></div></div>
-                        <div className="flex items-start gap-3"><SimCardIcon className="h-5 w-5 mt-1 opacity-75"/><div><label className="font-semibold">Your Local SIM Number</label><input type="text" value={localSim} onChange={(e) => setLocalSim(e.target.value)} placeholder="Enter your local number" className="w-full mt-1 p-1 border rounded bg-white bg-opacity-20 border-white border-opacity-30" /></div></div>
-                        <div className="flex items-start gap-3"><MailIcon className="h-5 w-5 mt-1 opacity-75"/><div><label className="font-semibold">Your Email Address</label><input type="email" value={localEmail} onChange={(e) => setLocalEmail(e.target.value)} placeholder="Enter your email" className={`w-full mt-1 p-1 border rounded bg-white bg-opacity-20 border-white border-opacity-30 ${!isEmailEditable ? 'bg-black bg-opacity-20 cursor-not-allowed' : ''}`} disabled={!isEmailEditable} /></div></div>
-                    </div>
-                    <button onClick={handleSaveContactInfo} className="mt-4 bg-white text-red-800 font-semibold py-1 px-3 rounded-lg hover:bg-gray-200">Save My Info</button>
-                </div>
+      const refreshedDocument = await refreshDocument(documentToDownload, { force: true });
+      triggerDownload(refreshedDocument);
+    } catch (error) {
+      // The package shell displays the refresh error without leaving an unhandled event promise.
+      setActionMessage(error?.message || 'This document is not currently available.');
+    }
+  }, [customer, refreshDocument]);
 
-                {checklist.length > 0 && (<div className="mb-8"><div className="flex justify-between items-center mb-4"><h2 className="text-xl font-semibold text-gray-700 dark:text-gray-300">Your Pre-Travel Checklist</h2><button onClick={() => setIsChecklistVisible(!isChecklistVisible)} className="text-sm font-semibold text-red-800 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300">{isChecklistVisible ? 'Hide' : 'Show'}</button></div>{isChecklistVisible && (<div className="bg-slate-50 dark:bg-slate-700 p-4 rounded-lg border border-slate-200 dark:border-slate-600 space-y-3">{checklist.map(item => (<label key={item.id} className="flex items-center cursor-pointer p-2 rounded-md hover:bg-slate-100 dark:hover:bg-slate-600 transition-colors"><input type="checkbox" checked={item.completed} onChange={() => handleChecklistItemToggle(item.id)} className="h-5 w-5 rounded border-gray-300 text-red-600 focus:ring-red-500" /><span className={`ml-3 text-gray-700 dark:text-gray-300 ${item.completed ? 'line-through text-gray-500 dark:text-gray-400' : ''}`}>{item.text}</span></label>))}</div>)}</div>)}
-                
-                <h2 className="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-4">Your Documents</h2>
-                {visibleCategories.length > 0 ? (
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                        {visibleCategories.map(category => (
-                            <div key={category.name} className="bg-slate-50 dark:bg-slate-700 p-4 rounded-lg border border-slate-200 dark:border-slate-600">
-                                <h3 className="font-bold text-lg mb-4">{category.icon} {category.name}</h3>
-                                <div className="space-y-3">
-                                    {customer.documents.filter(doc => doc.category === category.name).map(file => (
-                                        <div key={file.id} className="bg-white dark:bg-gray-800 p-3 rounded-lg border dark:border-gray-700">
-                                            <div className="flex items-center truncate mb-3">
-                                                <FileIcon className="h-5 w-5 mr-3 flex-shrink-0 text-gray-500" />
-                                                <span className="truncate font-medium text-gray-800 dark:text-gray-200">{file.name}</span>
-                                            </div>
-                                            <div className="flex items-center justify-end gap-2">
-                                                <button onClick={() => setPreviewFile(file)} className="flex items-center bg-gray-200 text-gray-800 font-semibold py-1 px-3 rounded-lg hover:bg-gray-300 transition-colors text-sm dark:bg-gray-600 dark:text-gray-200 dark:hover:bg-gray-500"><PreviewIcon className="h-4 w-4 mr-2" />Preview</button>
-                                                <a href={file.url} download className="flex items-center bg-red-800 text-white font-semibold py-1 px-3 rounded-lg hover:bg-red-700 transition-colors text-sm"><DownloadIcon className="h-4 w-4 mr-2" />Download</a>
-                                            </div>
-                                        </div>
-                                    ))}
-                                </div>
-                            </div>
-                        ))}
-                    </div>
-                ) : (<div className="text-center py-12"><p className="text-gray-500">No documents have been uploaded for you yet.</p></div>)}
+  const handleViewHtml = useCallback(async (documentToView) => {
+    setActionMessage('');
+    if (!signedLinksNeedRefresh(customer)) {
+      openSecureTab(documentToView.preview_url);
+      return;
+    }
 
-                <div className="mt-8 pt-4 border-t border-gray-200 dark:border-gray-700">
-                    <div className="flex items-center justify-center text-sm text-gray-500 bg-slate-50 dark:bg-slate-700 p-3 rounded-lg">
-                        <InfoIcon className="h-5 w-5 mr-3 flex-shrink-0" />
-                        For your security, access to this portal will expire on {getExpiryDate()}. Please download any documents you wish to keep.
-                    </div>
-                    <p className="text-center text-xs text-gray-400 mt-4">Last Updated: {getLastUpdatedDate()}</p>
-                </div>
-            </div>
+    const placeholder = window.open('about:blank', '_blank');
+    if (placeholder) {
+      placeholder.opener = null;
+      try {
+        placeholder.document.title = 'Loading secure voucher…';
+        const meta = placeholder.document.createElement('meta');
+        meta.name = 'referrer';
+        meta.content = 'no-referrer';
+        placeholder.document.head.appendChild(meta);
+      } catch (_error) {
+        // The placeholder remains safe after its opener is cleared.
+      }
+    }
 
-            {previewFile && (<div className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center p-4 z-50"><div className="bg-white rounded-lg shadow-2xl w-full h-full max-w-4xl max-h-[90vh] flex flex-col"><div className="flex justify-between items-center p-4 border-b flex-shrink-0"><h3 className="font-bold text-lg truncate">{previewFile.name}</h3><button onClick={() => setPreviewFile(null)} className="text-gray-400 hover:text-gray-800"><XIcon className="h-6 w-6" /></button></div><div className="flex-grow p-2">{previewFile.url.toLowerCase().endsWith('.jpg') ? (<img src={previewFile.url} alt="Document Preview" className="w-full h-full object-contain" />) : (<iframe src={previewFile.url} title="Document Preview" className="w-full h-full border-0"></iframe>)}</div></div></div>)}
-        </>
-    );
-};
+    try {
+      const refreshedDocument = await refreshDocument(documentToView, { force: true });
+      openSecureTab(refreshedDocument.preview_url, placeholder);
+    } catch (error) {
+      placeholder?.close();
+      setActionMessage(error?.message || 'This voucher is not currently available.');
+    }
+  }, [customer, refreshDocument]);
+
+  const handlePreviewRefresh = useCallback(async (documentToRefresh) => {
+    const refreshedDocument = await refreshDocument(documentToRefresh, { force: true });
+    setPreviewDocument(refreshedDocument);
+    return refreshedDocument;
+  }, [refreshDocument]);
+
+  return (
+    <>
+      <div className="w-full rounded-2xl bg-white p-4 shadow-xl dark:bg-gray-800 sm:p-6 md:p-8">
+        <PackageHeader customer={customer} onLogout={onLogout} />
+
+        {(isRefreshing || refreshMessage || actionMessage) && (
+          <div
+            className={`mb-4 rounded-lg border p-3 text-sm ${refreshMessage || actionMessage ? 'border-amber-300 bg-amber-50 text-amber-950' : 'border-blue-200 bg-blue-50 text-blue-900'}`}
+            role={refreshMessage || actionMessage ? 'alert' : 'status'}
+            aria-live="polite"
+          >
+            {isRefreshing ? 'Refreshing your secure document links…' : refreshMessage || actionMessage}
+          </div>
+        )}
+
+        <div className="sticky top-0 z-10 -mx-4 mb-6 border-y border-gray-200 bg-white/95 px-4 py-2 backdrop-blur dark:border-gray-700 dark:bg-gray-800/95 sm:mx-0 sm:rounded-lg sm:border sm:px-2">
+          <div className="flex gap-2 overflow-x-auto" role="tablist" aria-label="Package sections" aria-orientation="horizontal">
+            {tabs.map((tab, index) => {
+              const selected = tab.id === activeTab;
+              return (
+                <button
+                  key={tab.id}
+                  type="button"
+                  id={`package-tab-${tab.id}`}
+                  role="tab"
+                  aria-selected={selected}
+                  aria-controls={`package-panel-${tab.id}`}
+                  tabIndex={selected ? 0 : -1}
+                  onClick={() => setActiveTab(tab.id)}
+                  onKeyDown={(event) => handleTabKeyDown(event, index)}
+                  className={`min-h-10 shrink-0 rounded-full px-4 py-2 text-sm font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-red-500 ${selected ? 'bg-red-800 text-white' : 'border border-red-800 text-red-800 hover:bg-red-50 dark:text-red-200 dark:hover:bg-gray-700'}`}
+                >
+                  {tab.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div
+          id={`package-panel-${activeTab}`}
+          role="tabpanel"
+          aria-labelledby={`package-tab-${activeTab}`}
+          tabIndex={0}
+          className="focus:outline-none"
+        >
+          {activeTab === 'overview' && <PackageOverview customer={customer} />}
+          {activeTab === 'documents' && (
+            <>
+              <div className="mb-4 flex justify-end">
+                <button
+                  type="button"
+                  onClick={() => onRefreshPackage({ force: true }).catch(() => {})}
+                  disabled={isRefreshing}
+                  className="min-h-10 rounded-lg border border-gray-300 px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 disabled:cursor-wait disabled:opacity-60 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+                >
+                  {isRefreshing ? 'Refreshing…' : 'Refresh secure links'}
+                </button>
+              </div>
+              <PackageDocuments
+                documents={customer.documents}
+                onPreview={setPreviewDocument}
+                onDownload={handleDownload}
+                onViewHtml={handleViewHtml}
+              />
+            </>
+          )}
+          {activeTab === 'transport' && <PackageTransportVoucher voucher={customer.transportVoucher} />}
+          {activeTab === 'invoice' && <PackageInvoice invoice={customer.releasedInvoice} />}
+        </div>
+      </div>
+
+      <PackageDocumentPreview
+        document={previewDocument}
+        onClose={() => setPreviewDocument(null)}
+        onRefreshDocument={handlePreviewRefresh}
+      />
+    </>
+  );
+}
 
 export default function ClientPortal() {
-    const [loggedInCustomer, setLoggedInCustomer] = useState(null);
-    const [isLoading, setIsLoading] = useState(false);
-    const handleLogin = (customer) => { setLoggedInCustomer(customer); };
-    const handleLogout = () => { setLoggedInCustomer(null); };
-    const handleCustomerUpdate = (updatedData) => { setLoggedInCustomer(updatedData); };
-    return (<div className="bg-slate-50 dark:bg-slate-900 min-h-screen flex items-center justify-center p-4"><div className="w-full max-w-5xl">{isLoading ? (<div className="text-center"><p className="text-gray-500">Loading...</p></div>) : loggedInCustomer ? (<ClientDashboard customer={loggedInCustomer} onLogout={handleLogout} onCustomerUpdate={handleCustomerUpdate} />) : (<ClientLoginPage onLogin={handleLogin} setIsLoading={setIsLoading} />)}</div></div>);
+  const { token } = useParams();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [portalPackage, setPortalPackage] = useState(null);
+  const [isRouteLoading, setIsRouteLoading] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [refreshMessage, setRefreshMessage] = useState('');
+  const [portalError, setPortalError] = useState(null);
+  const credentialRef = useRef(null);
+  const packageRef = useRef(null);
+  const refreshPromiseRef = useRef(null);
+  const skipNextDocumentsLoadRef = useRef(false);
+  const customerStateVersionRef = useRef(0);
+
+  const commitPackage = useCallback((nextPackage) => {
+    packageRef.current = nextPackage;
+    setPortalPackage(nextPackage);
+  }, []);
+
+  useEffect(() => {
+    const directToken = typeof token === 'string' && token ? token : null;
+    const isSessionRoute = location.pathname === '/documents';
+    if (!directToken && !isSessionRoute) return undefined;
+
+    if (isSessionRoute && skipNextDocumentsLoadRef.current && packageRef.current) {
+      skipNextDocumentsLoadRef.current = false;
+      return undefined;
+    }
+
+    const controller = new AbortController();
+    let cancelled = false;
+    setIsRouteLoading(true);
+    setPortalError(null);
+    setRefreshMessage('');
+
+    (async () => {
+      try {
+        const payload = await loadPackageData(directToken, { signal: controller.signal });
+        if (cancelled) return;
+
+        const normalized = normalizePtPortalPackage(payload);
+        const sessionEstablished = payload.sessionEstablished === true || !directToken;
+        credentialRef.current = sessionEstablished ? null : directToken;
+        commitPackage(normalized);
+
+        if (directToken && sessionEstablished) {
+          skipNextDocumentsLoadRef.current = true;
+          navigate('/documents', { replace: true });
+        }
+      } catch (error) {
+        if (cancelled || error?.name === 'AbortError') return;
+        credentialRef.current = null;
+        commitPackage(null);
+        setPortalError({
+          title: Number(error?.status) === 410 ? 'Access expired' : 'Package unavailable',
+          message: getPackageErrorMessage(error, 'token')
+        });
+      } finally {
+        if (!cancelled) setIsRouteLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [commitPackage, location.pathname, navigate, token]);
+
+  const refreshPackage = useCallback(async ({ force = false } = {}) => {
+    const currentPackage = packageRef.current;
+    if (!currentPackage || currentPackage.source !== 'pt_portal') return currentPackage;
+    if (!force && !signedLinksNeedRefresh(currentPackage)) return currentPackage;
+    if (refreshPromiseRef.current) return refreshPromiseRef.current;
+
+    const refreshRequest = (async () => {
+      const stateVersion = customerStateVersionRef.current;
+      setIsRefreshing(true);
+      setRefreshMessage('');
+      try {
+        const payload = await loadPackageData(credentialRef.current);
+        if (stateVersion !== customerStateVersionRef.current) return packageRef.current;
+        const normalized = normalizePtPortalPackage(payload);
+        if (payload.sessionEstablished === true) {
+          credentialRef.current = null;
+        }
+        commitPackage(normalized);
+        return normalized;
+      } catch (error) {
+        if (stateVersion !== customerStateVersionRef.current) return packageRef.current;
+        const status = Number(error?.status);
+        if ([400, 404, 410].includes(status)) {
+          credentialRef.current = null;
+          commitPackage(null);
+          setPortalError({
+            title: status === 410 ? 'Access expired' : 'Package unavailable',
+            message: getPackageErrorMessage(error, 'token')
+          });
+        } else {
+          setRefreshMessage(getPackageErrorMessage(error, 'token'));
+        }
+        throw error;
+      } finally {
+        setIsRefreshing(false);
+      }
+    })();
+
+    refreshPromiseRef.current = refreshRequest;
+    try {
+      return await refreshRequest;
+    } finally {
+      if (refreshPromiseRef.current === refreshRequest) refreshPromiseRef.current = null;
+    }
+  }, [commitPackage]);
+
+  useEffect(() => {
+    if (portalPackage?.source !== 'pt_portal') return undefined;
+    const lifetimeSeconds = Number(portalPackage.signedUrlExpiresIn);
+    const loadedAt = Date.parse(portalPackage.loadedAt || '');
+    if (!Number.isFinite(lifetimeSeconds) || lifetimeSeconds <= 0 || !Number.isFinite(loadedAt)) return undefined;
+
+    const lifetimeMs = lifetimeSeconds * 1000;
+    const leeway = Math.min(SIGNED_LINK_REFRESH_LEEWAY_MS, Math.max(1_000, lifetimeMs * 0.1));
+    const refreshAt = loadedAt + lifetimeMs - leeway;
+    const delay = Math.min(Math.max(refreshAt - Date.now(), 1_000), 2_147_000_000);
+    const timer = window.setTimeout(() => {
+      refreshPackage({ force: true }).catch(() => {});
+    }, delay);
+    return () => window.clearTimeout(timer);
+  }, [portalPackage, refreshPackage]);
+
+  const handleAuthenticated = useCallback(async ({
+    package: authenticatedPackage,
+    credential,
+    sessionEstablished
+  }) => {
+    credentialRef.current = credential || null;
+    setPortalError(null);
+    setRefreshMessage('');
+    commitPackage(authenticatedPackage);
+
+    if (authenticatedPackage.source === 'pt_portal' && sessionEstablished) {
+      skipNextDocumentsLoadRef.current = true;
+      navigate('/documents', { replace: true });
+    }
+  }, [commitPackage, navigate]);
+
+  const clearCustomerState = useCallback(() => {
+    customerStateVersionRef.current += 1;
+    credentialRef.current = null;
+    refreshPromiseRef.current = null;
+    setPortalError(null);
+    setRefreshMessage('');
+    commitPackage(null);
+  }, [commitPackage]);
+
+  const handleLogout = useCallback(async () => {
+    try {
+      await logoutPackageSession();
+    } catch (_error) {
+      // Local package state is still cleared; the next protected request revalidates upstream access.
+    } finally {
+      clearCustomerState();
+      navigate('/', { replace: true });
+    }
+  }, [clearCustomerState, navigate]);
+
+  const returnToLogin = useCallback(() => {
+    logoutPackageSession().catch(() => {});
+    clearCustomerState();
+    navigate('/', { replace: true });
+  }, [clearCustomerState, navigate]);
+
+  const updateLegacyCustomer = useCallback((updatedCustomer) => {
+    commitPackage(updatedCustomer);
+  }, [commitPackage]);
+
+  let content;
+  if (isRouteLoading) {
+    content = <LoadingPanel />;
+  } else if (portalError) {
+    content = (
+      <PackageErrorState
+        title={portalError.title}
+        message={portalError.message}
+        actionLabel="Return to package login"
+        onAction={returnToLogin}
+      />
+    );
+  } else if (portalPackage?.source === 'pt_portal') {
+    content = (
+      <PtPortalDashboard
+        customer={portalPackage}
+        isRefreshing={isRefreshing}
+        refreshMessage={refreshMessage}
+        onLogout={handleLogout}
+        onRefreshPackage={refreshPackage}
+      />
+    );
+  } else if (portalPackage?.source === 'legacy_firebase') {
+    content = (
+      <Suspense fallback={<LoadingPanel message="Loading legacy package…" />}>
+        <LegacyClientDashboard
+          customer={portalPackage}
+          onLogout={handleLogout}
+          onCustomerUpdate={updateLegacyCustomer}
+        />
+      </Suspense>
+    );
+  } else {
+    content = <PackageLogin onAuthenticated={handleAuthenticated} />;
+  }
+
+  const isDashboard = Boolean(portalPackage);
+  return (
+    <main className={`min-h-screen bg-slate-50 p-3 dark:bg-slate-900 sm:p-4 ${isDashboard ? 'flex items-start justify-center py-5 sm:py-8' : 'flex items-center justify-center'}`}>
+      <div className="w-full max-w-5xl">{content}</div>
+    </main>
+  );
 }

--- a/src/components/legacy/LegacyClientDashboard.jsx
+++ b/src/components/legacy/LegacyClientDashboard.jsx
@@ -1,0 +1,316 @@
+import React, { useEffect, useState } from 'react';
+import { doc, serverTimestamp, updateDoc } from 'firebase/firestore';
+import { db } from '../../firebase';
+import { fileCategories } from '../../data';
+import {
+  DownloadIcon,
+  FileIcon,
+  GlobeIcon,
+  InfoIcon,
+  MailIcon,
+  PreviewIcon,
+  SimCardIcon,
+  UserIcon,
+  XIcon
+} from '../Icons';
+
+function formatExpiryDate(customer) {
+  const dateToUse = customer.accessExpiresAt || customer.createdAt;
+  if (!dateToUse) return 'N/A';
+
+  const expiryBaseDate = new Date(dateToUse);
+  if (Number.isNaN(expiryBaseDate.getTime())) return 'N/A';
+
+  if (!customer.accessExpiresAt) {
+    expiryBaseDate.setMonth(expiryBaseDate.getMonth() + 10);
+  }
+
+  return expiryBaseDate.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric'
+  });
+}
+
+function formatLastUpdated(value) {
+  if (!value) return 'Not available';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? 'Not available' : date.toLocaleString('en-GB');
+}
+
+function getLegacyPreviewKind(file) {
+  const candidate = `${file?.name || ''} ${file?.url || ''}`.split(/[?#]/, 1)[0].toLowerCase();
+  if (/\.(?:jpe?g|png|webp)(?:\s|$)/i.test(candidate)) return 'image';
+  if (/\.pdf(?:\s|$)/i.test(candidate)) return 'pdf';
+  return null;
+}
+
+export default function LegacyClientDashboard({ customer, onLogout, onCustomerUpdate }) {
+  const [previewFile, setPreviewFile] = useState(null);
+  const [isChecklistVisible, setIsChecklistVisible] = useState(true);
+  const [localSim, setLocalSim] = useState(customer.keyInformation?.customerSim || '');
+  const [localEmail, setLocalEmail] = useState(customer.keyInformation?.customerEmail || '');
+
+  useEffect(() => {
+    setLocalSim(customer.keyInformation?.customerSim || '');
+    setLocalEmail(customer.keyInformation?.customerEmail || '');
+  }, [customer]);
+
+  useEffect(() => {
+    if (!previewFile) return undefined;
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') setPreviewFile(null);
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [previewFile]);
+
+  const handleSaveContactInfo = async () => {
+    const newKeyInfo = {
+      ...customer.keyInformation,
+      customerSim: localSim,
+      customerEmail: localEmail,
+      isEmailLocked: true
+    };
+
+    try {
+      await updateDoc(doc(db, 'customers', customer.id), {
+        keyInformation: newKeyInfo,
+        lastUpdatedAt: serverTimestamp()
+      });
+      onCustomerUpdate({
+        ...customer,
+        keyInformation: newKeyInfo,
+        lastUpdatedAt: new Date().toISOString()
+      });
+      window.alert('Your contact information has been saved.');
+    } catch (_error) {
+      window.alert('Could not save your information. Please try again.');
+    }
+  };
+
+  const handleChecklistItemToggle = async (itemId) => {
+    const updatedChecklist = (customer.checklist || []).map((item) =>
+      item.id === itemId ? { ...item, completed: !item.completed } : item
+    );
+
+    try {
+      await updateDoc(doc(db, 'customers', customer.id), { checklist: updatedChecklist });
+      onCustomerUpdate({ ...customer, checklist: updatedChecklist });
+    } catch (_error) {
+      // Keep customer identifiers and Firestore document paths out of browser logs.
+      window.alert('Could not update your checklist. Please try again.');
+    }
+  };
+
+  const keyInfo = customer.keyInformation || {};
+  const checklist = customer.checklist || [];
+  const isEmailEditable = !keyInfo.isEmailLocked || !keyInfo.customerEmail;
+  const visibleCategories = fileCategories.filter((category) =>
+    customer.documents?.some((document) => document.category === category.name)
+  );
+
+  return (
+    <>
+      <div className="w-full rounded-2xl bg-white p-6 shadow-xl dark:bg-gray-800 md:p-8">
+        <header className="mb-8 flex flex-col items-start justify-between gap-4 border-b border-gray-200 pb-6 dark:border-gray-700 md:flex-row">
+          <div>
+            <p className="font-mono text-sm text-gray-500">Reference: {customer.referenceNumber}</p>
+            <h1 className="mt-1 text-3xl font-bold text-gray-800 dark:text-white md:text-4xl">
+              Welcome, {customer.firstName} {customer.lastName}
+            </h1>
+            <p className="mt-2 text-lg font-semibold text-gray-600 dark:text-gray-300">
+              {customer.packageType} to {customer.destination}
+            </p>
+          </div>
+          <div className="flex w-full flex-col items-start gap-3 md:w-auto md:items-end">
+            {customer.status === 'Completed' && (
+              <span className="rounded-full bg-green-200 px-4 py-2 text-base font-bold text-green-800 dark:bg-green-900 dark:text-green-300">
+                Package Completed
+              </span>
+            )}
+            <button
+              type="button"
+              onClick={onLogout}
+              className="w-full rounded-lg bg-gray-200 px-4 py-2 font-semibold text-gray-800 transition-colors hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 md:w-auto"
+            >
+              Log Out
+            </button>
+          </div>
+        </header>
+
+        <section className="mb-8 rounded-lg bg-red-800 p-4 text-white">
+          <h2 className="mb-4 text-lg font-bold">Key Information</h2>
+          <div className="grid grid-cols-1 gap-x-8 gap-y-4 text-sm md:grid-cols-2">
+            <div className="flex items-start gap-3">
+              <UserIcon className="mt-1 h-5 w-5 opacity-75" />
+              <div>
+                <p className="font-semibold">Your Agent</p>
+                <p className="opacity-90">{keyInfo.agentName}</p>
+                <p className="opacity-90">{keyInfo.agentContact}</p>
+                <p className="mt-1 text-xs italic opacity-75">{keyInfo.whatsAppNotes}</p>
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              <GlobeIcon className="mt-1 h-5 w-5 opacity-75" />
+              <div>
+                <p className="font-semibold">Ground Transport Manager</p>
+                <p className="opacity-90">{keyInfo.groundTransportManager}</p>
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              <SimCardIcon className="mt-1 h-5 w-5 opacity-75" />
+              <div className="min-w-0 flex-1">
+                <label htmlFor="legacy-local-sim" className="font-semibold">Your Local SIM Number</label>
+                <input
+                  id="legacy-local-sim"
+                  type="text"
+                  value={localSim}
+                  onChange={(event) => setLocalSim(event.target.value)}
+                  placeholder="Enter your local number"
+                  className="mt-1 w-full rounded border border-white/30 bg-white/20 p-1"
+                />
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              <MailIcon className="mt-1 h-5 w-5 opacity-75" />
+              <div className="min-w-0 flex-1">
+                <label htmlFor="legacy-email" className="font-semibold">Your Email Address</label>
+                <input
+                  id="legacy-email"
+                  type="email"
+                  value={localEmail}
+                  onChange={(event) => setLocalEmail(event.target.value)}
+                  placeholder="Enter your email"
+                  className={`mt-1 w-full rounded border border-white/30 bg-white/20 p-1 ${!isEmailEditable ? 'cursor-not-allowed bg-black/20' : ''}`}
+                  disabled={!isEmailEditable}
+                />
+              </div>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={handleSaveContactInfo}
+            className="mt-4 rounded-lg bg-white px-3 py-1 font-semibold text-red-800 hover:bg-gray-200"
+          >
+            Save My Info
+          </button>
+        </section>
+
+        {checklist.length > 0 && (
+          <section className="mb-8">
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-xl font-semibold text-gray-700 dark:text-gray-300">Your Pre-Travel Checklist</h2>
+              <button
+                type="button"
+                onClick={() => setIsChecklistVisible((visible) => !visible)}
+                className="text-sm font-semibold text-red-800 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300"
+              >
+                {isChecklistVisible ? 'Hide' : 'Show'}
+              </button>
+            </div>
+            {isChecklistVisible && (
+              <div className="space-y-3 rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-700">
+                {checklist.map((item) => (
+                  <label key={item.id} className="flex cursor-pointer items-center rounded-md p-2 transition-colors hover:bg-slate-100 dark:hover:bg-slate-600">
+                    <input
+                      type="checkbox"
+                      checked={Boolean(item.completed)}
+                      onChange={() => handleChecklistItemToggle(item.id)}
+                      className="h-5 w-5 rounded border-gray-300 text-red-600 focus:ring-red-500"
+                    />
+                    <span className={`ml-3 text-gray-700 dark:text-gray-300 ${item.completed ? 'text-gray-500 line-through dark:text-gray-400' : ''}`}>
+                      {item.text}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </section>
+        )}
+
+        <h2 className="mb-4 text-xl font-semibold text-gray-700 dark:text-gray-300">Your Documents</h2>
+        {visibleCategories.length > 0 ? (
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {visibleCategories.map((category) => (
+              <section key={category.name} className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-700">
+                <h3 className="mb-4 text-lg font-bold">{category.icon} {category.name}</h3>
+                <div className="space-y-3">
+                  {customer.documents
+                    .filter((document) => document.category === category.name)
+                    .map((file) => (
+                      <article key={file.id} className="rounded-lg border bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+                        <div className="mb-3 flex min-w-0 items-center">
+                          <FileIcon className="mr-3 h-5 w-5 flex-shrink-0 text-gray-500" />
+                          <span className="truncate font-medium text-gray-800 dark:text-gray-200">{file.name}</span>
+                        </div>
+                        <div className="flex flex-wrap items-center justify-end gap-2">
+                          {getLegacyPreviewKind(file) && (
+                            <button
+                              type="button"
+                              onClick={() => setPreviewFile(file)}
+                              className="flex items-center rounded-lg bg-gray-200 px-3 py-1 text-sm font-semibold text-gray-800 transition-colors hover:bg-gray-300 dark:bg-gray-600 dark:text-gray-200 dark:hover:bg-gray-500"
+                            >
+                              <PreviewIcon className="mr-2 h-4 w-4" />Preview
+                            </button>
+                          )}
+                          <a
+                            href={file.url}
+                            download={file.name}
+                            referrerPolicy="no-referrer"
+                            className="flex items-center rounded-lg bg-red-800 px-3 py-1 text-sm font-semibold text-white transition-colors hover:bg-red-700"
+                          >
+                            <DownloadIcon className="mr-2 h-4 w-4" />Download
+                          </a>
+                        </div>
+                      </article>
+                    ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        ) : (
+          <div className="py-12 text-center"><p className="text-gray-500">No documents have been uploaded for you yet.</p></div>
+        )}
+
+        <footer className="mt-8 border-t border-gray-200 pt-4 dark:border-gray-700">
+          <div className="flex items-center justify-center rounded-lg bg-slate-50 p-3 text-sm text-gray-500 dark:bg-slate-700">
+            <InfoIcon className="mr-3 h-5 w-5 flex-shrink-0" />
+            For your security, access to this portal will expire on {formatExpiryDate(customer)}. Please download any documents you wish to keep.
+          </div>
+          <p className="mt-4 text-center text-xs text-gray-400">Last Updated: {formatLastUpdated(customer.lastUpdatedAt)}</p>
+        </footer>
+      </div>
+
+      {previewFile && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/75 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="legacy-preview-title"
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget) setPreviewFile(null);
+          }}
+        >
+          <div className="flex h-full max-h-[90vh] w-full max-w-4xl flex-col rounded-lg bg-white shadow-2xl">
+            <div className="flex flex-shrink-0 items-center justify-between border-b p-4">
+              <h2 id="legacy-preview-title" className="truncate text-lg font-bold">{previewFile.name}</h2>
+              <button type="button" onClick={() => setPreviewFile(null)} className="text-gray-400 hover:text-gray-800" aria-label="Close document preview">
+                <XIcon className="h-6 w-6" />
+              </button>
+            </div>
+            <div className="flex-grow p-2">
+              {getLegacyPreviewKind(previewFile) === 'image' ? (
+                <img src={previewFile.url} alt={previewFile.name} referrerPolicy="no-referrer" className="h-full w-full object-contain" />
+              ) : (
+                <iframe src={previewFile.url} title={`${previewFile.name} preview`} referrerPolicy="no-referrer" className="h-full w-full border-0" />
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/portal/PackageDocumentPreview.jsx
+++ b/src/components/portal/PackageDocumentPreview.jsx
@@ -1,0 +1,196 @@
+import React, { useEffect, useId, useRef, useState } from 'react';
+import { XIcon } from '../Icons';
+import { classifyPortalDocument, DOCUMENT_KINDS } from '../../utils/packagePortal';
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])'
+].join(',');
+
+/**
+ * `onRefreshDocument(document, { reason: 'preview-error'|'customer-request' })`
+ * may be async and must return the same document with refreshed URLs. It is called
+ * at most once each time the modal opens.
+ */
+export default function PackageDocumentPreview({ document: documentToPreview, onClose, onRefreshDocument }) {
+  const titleId = useId();
+  const descriptionId = useId();
+  const dialogRef = useRef(null);
+  const closeButtonRef = useRef(null);
+  const previousFocusRef = useRef(null);
+  const [activeDocument, setActiveDocument] = useState(documentToPreview);
+  const [refreshAttempted, setRefreshAttempted] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [previewError, setPreviewError] = useState('');
+
+  useEffect(() => {
+    setActiveDocument(documentToPreview);
+    setRefreshAttempted(false);
+    setIsRefreshing(false);
+    setPreviewError('');
+  }, [documentToPreview]);
+
+  useEffect(() => {
+    if (!documentToPreview) return undefined;
+
+    previousFocusRef.current = document.activeElement;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const focusTimer = window.setTimeout(() => closeButtonRef.current?.focus(), 0);
+    const handleKeyDown = event => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose?.();
+        return;
+      }
+
+      if (event.key !== 'Tab' || !dialogRef.current) return;
+      const focusable = Array.from(dialogRef.current.querySelectorAll(FOCUSABLE_SELECTOR));
+      if (!focusable.length) {
+        event.preventDefault();
+        dialogRef.current.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.clearTimeout(focusTimer);
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = previousOverflow;
+      previousFocusRef.current?.focus?.();
+    };
+  }, [documentToPreview, onClose]);
+
+  if (!documentToPreview || !activeDocument) return null;
+
+  const kind = classifyPortalDocument(activeDocument);
+  const previewUrl = activeDocument.preview_url;
+  const canRetry = typeof onRefreshDocument === 'function' && !refreshAttempted;
+
+  const refreshPreview = async reason => {
+    if (!canRetry || isRefreshing) {
+      setPreviewError('This secure preview is unavailable. Download the document or refresh the package.');
+      return;
+    }
+
+    setRefreshAttempted(true);
+    setIsRefreshing(true);
+    setPreviewError('');
+    try {
+      const refreshedDocument = await onRefreshDocument(activeDocument, { reason });
+      if (!refreshedDocument?.preview_url) throw new Error('No refreshed preview URL was returned.');
+      setActiveDocument(refreshedDocument);
+    } catch (_error) {
+      setPreviewError('We could not refresh this secure preview. Please close it and try again.');
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+
+  const showPreview = previewUrl && [DOCUMENT_KINDS.PDF, DOCUMENT_KINDS.IMAGE].includes(kind);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 p-0 sm:p-4"
+      onMouseDown={event => {
+        if (event.target === event.currentTarget) onClose?.();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        tabIndex={-1}
+        className="flex h-[100dvh] w-full min-w-0 flex-col bg-white shadow-2xl dark:bg-gray-800 sm:max-h-[90vh] sm:max-w-4xl sm:rounded-lg"
+      >
+        <div className="flex min-w-0 flex-shrink-0 items-center justify-between gap-3 border-b p-4 dark:border-gray-700">
+          <div className="min-w-0">
+            <h2 id={titleId} className="truncate text-lg font-bold text-gray-800 dark:text-gray-100">{activeDocument.title}</h2>
+            <p id={descriptionId} className="text-xs text-gray-500">Secure document preview</p>
+          </div>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 hover:text-gray-800 focus:outline-none focus:ring-2 focus:ring-red-500 dark:hover:bg-gray-700 dark:hover:text-white"
+            aria-label="Close document preview"
+          >
+            <XIcon className="h-6 w-6" />
+          </button>
+        </div>
+
+        <div className="relative min-h-0 flex-grow p-2 sm:p-3">
+          {showPreview && kind === DOCUMENT_KINDS.PDF && (
+            <iframe
+              key={previewUrl}
+              src={previewUrl}
+              title={`${activeDocument.title} preview`}
+              referrerPolicy="no-referrer"
+              onError={() => refreshPreview('preview-error')}
+              className="h-full w-full border-0"
+            />
+          )}
+          {showPreview && kind === DOCUMENT_KINDS.IMAGE && (
+            <img
+              key={previewUrl}
+              src={previewUrl}
+              alt={`Preview of ${activeDocument.title}`}
+              referrerPolicy="no-referrer"
+              onError={() => refreshPreview('preview-error')}
+              className="h-full w-full object-contain"
+            />
+          )}
+          {!showPreview && (
+            <div className="flex h-full items-center justify-center p-6 text-center">
+              <div>
+                <p className="text-lg font-semibold text-gray-800 dark:text-gray-100">Preview not available</p>
+                <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">This file can be downloaded securely instead.</p>
+              </div>
+            </div>
+          )}
+
+          {isRefreshing && (
+            <div className="absolute inset-2 flex items-center justify-center bg-white bg-opacity-90 dark:bg-gray-800 dark:bg-opacity-90" role="status">
+              <p className="font-semibold text-gray-700 dark:text-gray-200">Refreshing your secure document link…</p>
+            </div>
+          )}
+        </div>
+
+        {(previewError || canRetry) && (
+          <div className="flex flex-col gap-2 border-t p-3 dark:border-gray-700 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-gray-600 dark:text-gray-300" role={previewError ? 'alert' : undefined}>
+              {previewError || 'If this secure preview has expired, refresh it once.'}
+            </p>
+            {canRetry && (
+              <button
+                type="button"
+                onClick={() => refreshPreview('customer-request')}
+                className="min-h-10 rounded-lg bg-gray-200 px-4 py-2 text-sm font-semibold text-gray-800 hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-red-500 dark:bg-gray-600 dark:text-gray-100"
+              >
+                Refresh secure link
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/portal/PackageDocuments.jsx
+++ b/src/components/portal/PackageDocuments.jsx
@@ -1,0 +1,181 @@
+import React, { useState } from 'react';
+import { FileIcon, PreviewIcon, DownloadIcon } from '../Icons';
+import {
+  classifyPortalDocument,
+  DOCUMENT_KINDS,
+  formatFileSize,
+  formatPortalDate,
+  normalizeDocumentCategory
+} from '../../utils/packagePortal';
+
+const CATEGORY_LABELS = {
+  flight: 'Flights',
+  hotel: 'Hotels',
+  transport: 'Transport',
+  visa: 'Visa',
+  e_sim: 'E-Sim',
+  insurance: 'Insurance',
+  invoice: 'Invoice',
+  other: 'Other'
+};
+
+const CATEGORY_ICONS = {
+  flight: '✈️',
+  hotel: '🏨',
+  transport: '🚗',
+  visa: '📄',
+  e_sim: '📱',
+  insurance: '🛡️',
+  invoice: '🧾',
+  other: '📎'
+};
+
+/**
+ * Props:
+ * - `onPreview(document)` opens a PDF/image modal.
+ * - optional `onDownload(document)` owns refresh + download; without it a secure link renders.
+ * - optional `onViewHtml(document)` owns refresh + View/Print; without it a secure new-tab link renders.
+ */
+export default function PackageDocuments({ documents, onPreview, onDownload, onViewHtml }) {
+  const [pendingAction, setPendingAction] = useState(null);
+  const [actionError, setActionError] = useState('');
+
+  const groupedDocuments = (Array.isArray(documents) ? documents : []).reduce((groups, document) => {
+    if (!document || typeof document !== 'object') return groups;
+    const key = normalizeDocumentCategory(document.category);
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(document);
+    return groups;
+  }, {});
+
+  const visibleCategories = Object.keys(groupedDocuments).filter(key => groupedDocuments[key].length > 0);
+
+  const runOwnedAction = async (actionName, document, callback) => {
+    if (typeof callback !== 'function') return;
+    const actionKey = `${actionName}:${document.id}`;
+    setActionError('');
+    setPendingAction(actionKey);
+    try {
+      await callback(document);
+    } catch (_error) {
+      setActionError('We could not refresh that secure document link. Please try again.');
+    } finally {
+      setPendingAction(current => current === actionKey ? null : current);
+    }
+  };
+
+  return (
+    <section className="mb-6" aria-labelledby="package-documents-heading">
+      <h2 id="package-documents-heading" className="mb-4 text-xl font-semibold text-gray-700 dark:text-gray-300">
+        Your Documents
+      </h2>
+      {actionError && <p className="mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-700" role="alert">{actionError}</p>}
+      {visibleCategories.length > 0 ? (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 lg:gap-6">
+          {visibleCategories.map(categoryKey => (
+            <section key={categoryKey} className="min-w-0 rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-slate-600 dark:bg-slate-700 sm:p-4">
+              <h3 className="mb-4 font-bold text-gray-800 dark:text-gray-100">
+                <span aria-hidden="true">{CATEGORY_ICONS[categoryKey] || '📄'} </span>
+                {CATEGORY_LABELS[categoryKey] || 'Other'}
+              </h3>
+              <div className="space-y-3">
+                {groupedDocuments[categoryKey].map(document => {
+                  const kind = classifyPortalDocument(document);
+                  const canModalPreview = Boolean(document.preview_url) && [DOCUMENT_KINDS.PDF, DOCUMENT_KINDS.IMAGE].includes(kind);
+                  const canViewHtml = Boolean(document.preview_url) && kind === DOCUMENT_KINDS.HTML;
+                  const downloadActionKey = `download:${document.id}`;
+                  const htmlActionKey = `html:${document.id}`;
+
+                  return (
+                    <article key={document.id} className="min-w-0 rounded-lg border bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+                      <div className="mb-2 flex min-w-0 items-start gap-3">
+                        <FileIcon className="mt-0.5 h-5 w-5 flex-shrink-0 text-gray-500" />
+                        <div className="min-w-0">
+                          <h4 className="break-words font-medium text-gray-800 dark:text-gray-200">{document.title}</h4>
+                          <p className="mt-0.5 text-xs text-gray-500">{CATEGORY_LABELS[categoryKey] || 'Other'}</p>
+                        </div>
+                      </div>
+
+                      <div className="mb-2 flex flex-wrap gap-x-2 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
+                        <span>{formatFileSize(document.file_size)}</span>
+                        {document.released_at && <span>Released {formatPortalDate(document.released_at)}</span>}
+                      </div>
+
+                      {document.public_notes && (
+                        <p className="mb-3 whitespace-pre-line break-words text-xs text-gray-600 dark:text-gray-300">
+                          {document.public_notes}
+                        </p>
+                      )}
+
+                      <div className="grid grid-cols-1 gap-2 min-[380px]:grid-cols-2">
+                        {canModalPreview && typeof onPreview === 'function' && (
+                          <button
+                            type="button"
+                            onClick={() => onPreview(document)}
+                            className="inline-flex min-h-10 items-center justify-center rounded-lg bg-gray-200 px-3 py-2 text-sm font-semibold text-gray-800 transition-colors hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:bg-gray-600 dark:text-gray-200 dark:hover:bg-gray-500"
+                            aria-label={`Preview ${document.title}`}
+                          >
+                            <PreviewIcon className="mr-2 h-4 w-4" />Preview
+                          </button>
+                        )}
+
+                        {canViewHtml && (typeof onViewHtml === 'function' ? (
+                          <button
+                            type="button"
+                            disabled={pendingAction === htmlActionKey}
+                            onClick={() => runOwnedAction('html', document, onViewHtml)}
+                            className="inline-flex min-h-10 items-center justify-center rounded-lg bg-gray-200 px-3 py-2 text-sm font-semibold text-gray-800 hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:cursor-wait disabled:opacity-60 dark:bg-gray-600 dark:text-gray-200"
+                          >
+                            <PreviewIcon className="mr-2 h-4 w-4" />
+                            {pendingAction === htmlActionKey ? 'Refreshing…' : 'View / Print'}
+                          </button>
+                        ) : (
+                          <a
+                            href={document.preview_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            referrerPolicy="no-referrer"
+                            className="inline-flex min-h-10 items-center justify-center rounded-lg bg-gray-200 px-3 py-2 text-sm font-semibold text-gray-800 hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:bg-gray-600 dark:text-gray-200"
+                          >
+                            <PreviewIcon className="mr-2 h-4 w-4" />View / Print
+                          </a>
+                        ))}
+
+                        {document.signed_url && (typeof onDownload === 'function' ? (
+                          <button
+                            type="button"
+                            disabled={pendingAction === downloadActionKey}
+                            onClick={() => runOwnedAction('download', document, onDownload)}
+                            className="inline-flex min-h-10 items-center justify-center rounded-lg bg-red-800 px-3 py-2 text-sm font-semibold text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:cursor-wait disabled:opacity-60"
+                          >
+                            <DownloadIcon className="mr-2 h-4 w-4" />
+                            {pendingAction === downloadActionKey ? 'Refreshing…' : 'Download'}
+                          </button>
+                        ) : (
+                          <a
+                            href={document.signed_url}
+                            download={document.file_name}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            referrerPolicy="no-referrer"
+                            className="inline-flex min-h-10 items-center justify-center rounded-lg bg-red-800 px-3 py-2 text-sm font-semibold text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+                          >
+                            <DownloadIcon className="mr-2 h-4 w-4" />Download
+                          </a>
+                        ))}
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+            </section>
+          ))}
+        </div>
+      ) : (
+        <div className="py-12 text-center" role="status">
+          <p className="text-gray-500">Your package is open, but no documents have been released yet.</p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/portal/PackageErrorState.jsx
+++ b/src/components/portal/PackageErrorState.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export default function PackageErrorState({ title = 'Package unavailable', message = 'Package documents are not currently available. Contact your agent.', actionLabel, onAction }) {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-8 w-full" role="alert">
+      <div className="max-w-xl mx-auto text-center">
+        <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-red-100 text-red-800">
+          <span className="text-3xl">!</span>
+        </div>
+        <h1 className="text-2xl font-bold text-gray-800 dark:text-white mb-2">{title}</h1>
+        <p className="text-gray-600 dark:text-gray-300">{message}</p>
+        {actionLabel && typeof onAction === 'function' && (
+          <button type="button" onClick={onAction} className="mt-6 min-h-11 rounded-lg bg-red-800 px-4 py-2 font-semibold text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2">
+            {actionLabel}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/portal/PackageHeader.jsx
+++ b/src/components/portal/PackageHeader.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { piyamTravelLogoBase64 } from '../../data';
+
+const PiyamTravelLogo = () => <img src={piyamTravelLogoBase64} alt="Piyam Travel Logo" className="h-auto max-w-full" />;
+
+export default function PackageHeader({ customer, onLogout }) {
+  const packageDescription = customer.packageType && customer.destination
+    ? `${customer.packageType} to ${customer.destination}`
+    : customer.packageType || customer.destination || 'Travel package';
+
+  return (
+    <div className="flex flex-col md:flex-row justify-between items-start mb-8 gap-4 border-b border-gray-200 dark:border-gray-700 pb-6">
+      <div className="flex min-w-0 items-start gap-3 sm:items-center sm:gap-4">
+        <div className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-full border border-red-100 bg-red-50">
+          <PiyamTravelLogo />
+        </div>
+        <div className="min-w-0">
+          <p className="break-all font-mono text-sm text-gray-500">Reference: {customer.reference}</p>
+          <h1 className="mt-1 break-words text-2xl font-bold text-gray-800 dark:text-white sm:text-3xl md:text-4xl">Welcome, {customer.customerName}</h1>
+          <p className="mt-2 break-words text-base font-semibold text-gray-600 dark:text-gray-300 sm:text-lg">{packageDescription}</p>
+        </div>
+      </div>
+      <div className="flex flex-col items-start md:items-end gap-3 w-full md:w-auto">
+        <button type="button" onClick={onLogout} className="min-h-11 w-full rounded-lg bg-gray-200 px-4 py-2 font-semibold text-gray-800 transition-colors hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 md:w-auto">Log Out</button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/portal/PackageInvoice.jsx
+++ b/src/components/portal/PackageInvoice.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { normalizeReleasedInvoice } from '../../adapters/portalReleaseAdapters';
+import { formatMoney, formatPortalDate, formatQuantity } from '../../utils/packagePortal';
+
+function AmountRow({ label, value, currency, strong = false }) {
+  const formatted = formatMoney(value, currency);
+  if (!formatted) return null;
+
+  return (
+    <div className={`flex items-baseline justify-between gap-4 ${strong ? 'border-t border-gray-300 pt-3 text-base font-bold dark:border-gray-600' : ''}`}>
+      <dt>{label}</dt>
+      <dd className="text-right tabular-nums">{formatted}</dd>
+    </div>
+  );
+}
+
+/** `invoice` may be raw or normalized; only explicitly whitelisted fields render. */
+export default function PackageInvoice({ invoice }) {
+  const safeInvoice = normalizeReleasedInvoice(invoice);
+  if (!safeInvoice) return null;
+
+  return (
+    <section className="mb-6" aria-labelledby="released-invoice-heading">
+      <div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h2 id="released-invoice-heading" className="text-xl font-semibold text-gray-700 dark:text-gray-300">
+            Released Invoice
+          </h2>
+          {safeInvoice.invoiceNumber && (
+            <p className="text-sm text-gray-500">Invoice {safeInvoice.invoiceNumber}</p>
+          )}
+        </div>
+        <div className="text-sm text-gray-500 sm:text-right">
+          {safeInvoice.version && <p>Version {safeInvoice.version}</p>}
+          {safeInvoice.releasedAt && <p>Released {formatPortalDate(safeInvoice.releasedAt)}</p>}
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        {safeInvoice.lines.length > 0 && (
+          <div className="space-y-3" aria-label="Invoice items">
+            {safeInvoice.lines.map(line => (
+              <article key={line.id} className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-600 dark:bg-gray-800">
+                <h3 className="break-words font-semibold text-gray-800 dark:text-gray-100">{line.description}</h3>
+                <dl className="mt-2 grid grid-cols-1 gap-2 text-sm text-gray-600 dark:text-gray-300 sm:grid-cols-3">
+                  {line.quantity !== null && (
+                    <div>
+                      <dt className="text-xs uppercase tracking-wide text-gray-500">Quantity</dt>
+                      <dd>{formatQuantity(line.quantity)}</dd>
+                    </div>
+                  )}
+                  {line.soldAmount !== null && (
+                    <div>
+                      <dt className="text-xs uppercase tracking-wide text-gray-500">Sold amount</dt>
+                      <dd className="tabular-nums">{formatMoney(line.soldAmount, safeInvoice.currency)}</dd>
+                    </div>
+                  )}
+                  {line.lineTotal !== null && (
+                    <div className="sm:text-right">
+                      <dt className="text-xs uppercase tracking-wide text-gray-500">Line total</dt>
+                      <dd className="font-semibold tabular-nums">{formatMoney(line.lineTotal, safeInvoice.currency)}</dd>
+                    </div>
+                  )}
+                </dl>
+              </article>
+            ))}
+          </div>
+        )}
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-gray-700 dark:border-slate-600 dark:bg-slate-700 dark:text-gray-200">
+            <dl className="space-y-3">
+              <AmountRow label="Subtotal" value={safeInvoice.subtotal} currency={safeInvoice.currency} />
+              <AmountRow label="Discount" value={safeInvoice.discount} currency={safeInvoice.currency} />
+              <AmountRow label="Total" value={safeInvoice.total} currency={safeInvoice.currency} strong />
+              <AmountRow label="Amount paid" value={safeInvoice.amountPaid} currency={safeInvoice.currency} />
+              <AmountRow label="Balance due" value={safeInvoice.balanceDue} currency={safeInvoice.currency} strong />
+            </dl>
+            {safeInvoice.dueDate && (
+              <p className="mt-4 border-t border-gray-300 pt-3 dark:border-gray-600">
+                <span className="font-semibold">Due date:</span> {formatPortalDate(safeInvoice.dueDate)}
+              </p>
+            )}
+          </div>
+
+          {safeInvoice.customerTerms && (
+            <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-700">
+              <h3 className="font-semibold text-gray-800 dark:text-gray-100">Customer terms</h3>
+              <p className="mt-2 whitespace-pre-line break-words text-sm text-gray-600 dark:text-gray-300">
+                {safeInvoice.customerTerms}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/portal/PackageLogin.jsx
+++ b/src/components/portal/PackageLogin.jsx
@@ -1,0 +1,228 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { UserIcon } from '../Icons';
+import { PackagePortalApiError, resolvePackageAccess, loadPackageData } from '../../services/packagePortalApi';
+import { normalizePtPortalPackage } from '../../adapters/ptPortalPackageAdapter';
+import { normalizeLegacyPackage } from '../../adapters/legacyPackageAdapter';
+import { piyamTravelLogoBase64 } from '../../data';
+import { getPackageErrorMessage } from '../../services/packageErrorResolver';
+
+const PiyamTravelLogo = () => <img src={piyamTravelLogoBase64} alt="Piyam Travel Logo" className="h-auto max-w-full" />;
+
+export function normalizeReferenceInput(value) {
+  const normalized = String(value || '').trim().toUpperCase();
+  return normalized.startsWith('PT-') ? normalized.slice(3) : normalized;
+}
+
+/**
+ * Successful callback contract:
+ * `onAuthenticated({ package, credential, sessionEstablished })` is preferred.
+ * For the existing shell, `onLogin(package, metadata)` receives equivalent data.
+ * The bearer credential is never attached to the normalized package object.
+ */
+export default function PackageLogin({ onAuthenticated, onLogin }) {
+  const [refNumber, setRefNumber] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [error, setError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [retryUntil, setRetryUntil] = useState(0);
+  const [retrySeconds, setRetrySeconds] = useState(0);
+  const requestControllerRef = useRef(null);
+
+  useEffect(() => () => requestControllerRef.current?.abort(), []);
+
+  useEffect(() => {
+    if (!retryUntil) {
+      setRetrySeconds(0);
+      return undefined;
+    }
+
+    const updateCountdown = () => {
+      const remaining = Math.max(0, Math.ceil((retryUntil - Date.now()) / 1000));
+      setRetrySeconds(remaining);
+      if (remaining === 0) setRetryUntil(0);
+    };
+
+    updateCountdown();
+    const timer = window.setInterval(updateCountdown, 1000);
+    return () => window.clearInterval(timer);
+  }, [retryUntil]);
+
+  const notifyAuthenticated = async result => {
+    if (typeof onAuthenticated === 'function') {
+      await onAuthenticated(result);
+      return;
+    }
+
+    if (typeof onLogin === 'function') {
+      await onLogin(result.package, {
+        source: result.package.source,
+        credential: result.credential,
+        sessionEstablished: result.sessionEstablished
+      });
+      return;
+    }
+
+    throw new Error('PackageLogin requires onAuthenticated or onLogin.');
+  };
+
+  const handleSubmit = async event => {
+    event.preventDefault();
+    if (isSubmitting || retrySeconds > 0) return;
+
+    const normalizedReference = normalizeReferenceInput(refNumber);
+    if (!/^[A-Z0-9]{6}$/.test(normalizedReference)) {
+      setError('Enter exactly six letters or numbers shown after PT- on your package reference.');
+      return;
+    }
+    if (!lastName.trim()) {
+      setError('Enter the lead passenger surname.');
+      return;
+    }
+
+    setError('');
+    setIsSubmitting(true);
+    requestControllerRef.current?.abort();
+    const controller = new AbortController();
+    requestControllerRef.current = controller;
+
+    try {
+      const accessData = await resolvePackageAccess(normalizedReference, lastName.trim(), { signal: controller.signal });
+
+      if (accessData?.source === 'pt_portal') {
+        const sessionEstablished = accessData.sessionEstablished === true;
+        const token = typeof accessData.token === 'string' && accessData.token.trim()
+          ? accessData.token.trim()
+          : null;
+
+        if (!sessionEstablished && !token) {
+          throw new PackagePortalApiError('The package service is temporarily unavailable. Please try again shortly.', {
+            status: 503,
+            code: 'MISSING_PACKAGE_CREDENTIAL'
+          });
+        }
+
+        const packageData = accessData.package && accessData.documents
+          ? accessData
+          : await loadPackageData(sessionEstablished ? null : token, { signal: controller.signal });
+        const normalizedPackage = normalizePtPortalPackage(packageData);
+        const effectiveSessionEstablished = sessionEstablished || packageData.sessionEstablished === true;
+
+        await notifyAuthenticated({
+          package: normalizedPackage,
+          credential: effectiveSessionEstablished ? null : token,
+          sessionEstablished: effectiveSessionEstablished
+        });
+        return;
+      }
+
+      if (accessData?.source === 'legacy_firebase') {
+        await notifyAuthenticated({
+          package: normalizeLegacyPackage(accessData.customer),
+          credential: null,
+          sessionEstablished: false
+        });
+        return;
+      }
+
+      throw new PackagePortalApiError('Package details do not match. Check the lead passenger surname and reference.', {
+        status: 404,
+        code: 'UNKNOWN_PACKAGE_SOURCE'
+      });
+    } catch (requestError) {
+      if (requestError?.name === 'AbortError') return;
+
+      setError(getPackageErrorMessage(requestError, 'access'));
+      if (Number(requestError?.status) === 429) {
+        const waitSeconds = Number.isFinite(Number(requestError.retryAfter)) && Number(requestError.retryAfter) > 0
+          ? Math.min(3600, Math.ceil(Number(requestError.retryAfter)))
+          : 60;
+        setRetrySeconds(waitSeconds);
+        setRetryUntil(Date.now() + waitSeconds * 1000);
+      }
+    } finally {
+      if (requestControllerRef.current === controller) requestControllerRef.current = null;
+      setIsSubmitting(false);
+    }
+  };
+
+  const errorId = error ? 'package-login-error' : undefined;
+  const retryId = retrySeconds > 0 ? 'package-login-retry' : undefined;
+  const describedBy = [errorId, retryId].filter(Boolean).join(' ') || undefined;
+
+  return (
+    <div className="overflow-hidden rounded-2xl border-t-4 border-red-800 bg-white shadow-xl dark:bg-gray-800">
+      <div className="p-5 sm:p-8">
+        <div className="mb-6 flex justify-center"><PiyamTravelLogo /></div>
+        <h1 className="mb-2 text-center text-2xl font-bold text-gray-800 dark:text-gray-200">Client Document Portal</h1>
+        <p className="mb-8 text-center text-gray-500">Access your travel documents securely.</p>
+
+        <form className="space-y-6" onSubmit={handleSubmit} aria-busy={isSubmitting} noValidate>
+          <div>
+            <label htmlFor="refNumber" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Package reference</label>
+            <div className="mt-1 flex min-w-0 items-center">
+              <span className="inline-flex min-h-11 items-center rounded-l-md border border-r-0 border-gray-300 bg-gray-50 px-3 text-gray-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-400" aria-hidden="true">PT-</span>
+              <input
+                type="text"
+                id="refNumber"
+                value={refNumber}
+                onChange={event => setRefNumber(normalizeReferenceInput(event.target.value))}
+                onPaste={event => {
+                  event.preventDefault();
+                  setRefNumber(normalizeReferenceInput(event.clipboardData.getData('text')));
+                }}
+                placeholder="H29GPX"
+                className="block min-h-11 min-w-0 flex-1 rounded-none rounded-r-lg border border-gray-300 p-2 uppercase focus:border-red-500 focus:ring-red-500 dark:border-gray-600 dark:bg-gray-900"
+                autoComplete="off"
+                autoCapitalize="characters"
+                spellCheck="false"
+                minLength={6}
+                maxLength={32}
+                pattern="[A-Za-z0-9]{6}"
+                aria-describedby={describedBy}
+                aria-invalid={Boolean(error)}
+                required
+              />
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="lastName" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Lead passenger surname</label>
+            <div className="relative mt-1">
+              <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3"><UserIcon className="h-5 w-5 text-gray-400" /></div>
+              <input
+                type="text"
+                id="lastName"
+                value={lastName}
+                onChange={event => setLastName(event.target.value)}
+                placeholder="Lead passenger surname"
+                className="min-h-11 w-full rounded-lg border border-gray-300 py-2 pl-10 pr-4 focus:border-red-800 focus:ring-red-800 dark:border-gray-600 dark:bg-gray-900"
+                autoComplete="family-name"
+                maxLength={100}
+                aria-describedby={describedBy}
+                aria-invalid={Boolean(error)}
+                required
+              />
+            </div>
+          </div>
+
+          <div className="min-h-5 text-center" aria-live="assertive">
+            {error && <p id={errorId} className="text-sm text-red-600" role="alert">{error}</p>}
+            {retrySeconds > 0 && (
+              <p id={retryId} className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+                You can try again in {retrySeconds} second{retrySeconds === 1 ? '' : 's'}.
+              </p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting || retrySeconds > 0}
+            className="flex min-h-12 w-full justify-center rounded-lg border border-transparent bg-red-800 px-4 py-3 text-sm font-medium text-white shadow-sm transition-colors hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:cursor-wait disabled:bg-red-400"
+          >
+            {isSubmitting ? 'Opening your package…' : retrySeconds > 0 ? `Try again in ${retrySeconds}s` : 'Access Documents'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/portal/PackageOverview.jsx
+++ b/src/components/portal/PackageOverview.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { formatPortalDate } from '../../utils/packagePortal';
+
+function formatSummaryLabel(key) {
+  return String(key)
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/^./, character => character.toUpperCase());
+}
+
+function formatSummaryValue(value) {
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  return String(value);
+}
+
+export default function PackageOverview({ customer }) {
+  const publicSummary = customer?.publicSummary && typeof customer.publicSummary === 'object'
+    ? Object.entries(customer.publicSummary).filter(([, value]) => ['string', 'number', 'boolean'].includes(typeof value))
+    : [];
+  const checklist = Array.isArray(customer?.checklist) ? customer.checklist : [];
+
+  return (
+    <section className="mb-6 space-y-4" aria-labelledby="package-overview-heading">
+      <h2 id="package-overview-heading" className="sr-only">Package overview</h2>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="rounded-lg bg-red-800 p-4 text-white">
+          <h3 className="mb-2 text-lg font-bold">Package Summary</h3>
+          <dl className="space-y-1 text-sm">
+            <div><dt className="inline font-semibold">Destination: </dt><dd className="inline break-words">{customer?.destination || 'Not supplied'}</dd></div>
+            <div><dt className="inline font-semibold">Departure: </dt><dd className="inline">{formatPortalDate(customer?.departureDate)}</dd></div>
+            <div><dt className="inline font-semibold">Return: </dt><dd className="inline">{formatPortalDate(customer?.returnDate)}</dd></div>
+            <div><dt className="inline font-semibold">Access expires: </dt><dd className="inline">{formatPortalDate(customer?.accessExpiresAt)}</dd></div>
+          </dl>
+        </div>
+
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-700">
+          <h3 className="mb-2 text-lg font-bold">Package Status</h3>
+          <dl className="space-y-1 text-sm text-gray-700 dark:text-gray-200">
+            <div><dt className="inline font-semibold">Status: </dt><dd className="inline capitalize">{customer?.statusLabel || 'Open'}</dd></div>
+            <div><dt className="inline font-semibold">Customer email: </dt><dd className="inline break-all">{customer?.keyInformation?.customerEmail || 'Not supplied'}</dd></div>
+          </dl>
+        </div>
+      </div>
+
+      {publicSummary.length > 0 && (
+        <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-600 dark:bg-gray-800">
+          <h3 className="mb-3 font-bold text-gray-800 dark:text-gray-100">Public information</h3>
+          <dl className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+            {publicSummary.map(([key, value]) => (
+              <div key={key} className="min-w-0">
+                <dt className="font-semibold text-gray-700 dark:text-gray-200">{formatSummaryLabel(key)}</dt>
+                <dd className="break-words text-gray-600 dark:text-gray-300">{formatSummaryValue(value)}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      )}
+
+      {checklist.length > 0 && (
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-700">
+          <h3 className="mb-3 font-bold text-gray-800 dark:text-gray-100">Travel checklist status</h3>
+          <ul className="space-y-2" aria-label="Read-only travel checklist">
+            {checklist.map((item, index) => (
+              <li key={item.id || `checklist-${index}`} className="flex items-start gap-3 rounded-md bg-white p-3 dark:bg-gray-800">
+                <span
+                  className={`mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-xs font-bold ${item.completed ? 'bg-green-100 text-green-800' : 'bg-gray-200 text-gray-600 dark:bg-gray-600 dark:text-gray-100'}`}
+                  aria-hidden="true"
+                >
+                  {item.completed ? '✓' : '•'}
+                </span>
+                <div className="min-w-0">
+                  <p className="break-words text-sm font-medium text-gray-800 dark:text-gray-100">{item.label || item.text}</p>
+                  {item.status && <p className="text-xs capitalize text-gray-500">{item.status}</p>}
+                  <span className="sr-only">{item.completed ? 'Complete' : 'Not complete'}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+          <p className="mt-3 text-xs text-gray-500">This information is read-only. Contact your agent if anything needs changing.</p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/portal/PackageTransportVoucher.jsx
+++ b/src/components/portal/PackageTransportVoucher.jsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { normalizeTransportVoucher } from '../../adapters/portalReleaseAdapters';
+import { formatPortalDate } from '../../utils/packagePortal';
+
+function JourneyCard({ title, details }) {
+  if (!details) return null;
+
+  return (
+    <article className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-600 dark:bg-gray-800">
+      <h3 className="font-semibold text-gray-800 dark:text-gray-100">{title}</h3>
+      <dl className="mt-2 space-y-1 text-sm text-gray-600 dark:text-gray-300">
+        {details.summary && <div><dt className="sr-only">Summary</dt><dd className="break-words">{details.summary}</dd></div>}
+        {details.date && <div><dt className="inline font-semibold">Date: </dt><dd className="inline">{formatPortalDate(details.date)}</dd></div>}
+        {details.time && <div><dt className="inline font-semibold">Time: </dt><dd className="inline">{details.time}</dd></div>}
+        {details.flightNumber && <div><dt className="inline font-semibold">Flight: </dt><dd className="inline">{details.flightNumber}</dd></div>}
+        {details.airport && <div><dt className="inline font-semibold">Airport: </dt><dd className="inline">{details.airport}</dd></div>}
+        {details.terminal && <div><dt className="inline font-semibold">Terminal: </dt><dd className="inline">{details.terminal}</dd></div>}
+        {details.location && <div><dt className="inline font-semibold">Location: </dt><dd className="inline break-words">{details.location}</dd></div>}
+      </dl>
+    </article>
+  );
+}
+
+function ContactCard({ title, contact }) {
+  if (!contact) return null;
+  const telephoneTarget = String(contact.phone || '').replace(/[^+0-9]/g, '');
+  const emailTarget = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(contact.email || ''))
+    ? String(contact.email)
+    : '';
+
+  return (
+    <article className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-600 dark:bg-gray-800">
+      <h3 className="font-semibold text-gray-800 dark:text-gray-100">{title}</h3>
+      <div className="mt-2 space-y-1 break-words text-sm text-gray-600 dark:text-gray-300">
+        {contact.name && <p>{contact.name}</p>}
+        {contact.phone && <p>{telephoneTarget ? <a className="underline" href={`tel:${telephoneTarget}`}>{contact.phone}</a> : contact.phone}</p>}
+        {contact.whatsApp && <p>WhatsApp: {contact.whatsApp}</p>}
+        {contact.email && <p>{emailTarget ? <a className="underline" href={`mailto:${emailTarget}`}>{contact.email}</a> : contact.email}</p>}
+      </div>
+    </article>
+  );
+}
+
+/** `voucher` may be raw or normalized; only explicitly whitelisted fields render. */
+export default function PackageTransportVoucher({ voucher }) {
+  const safeVoucher = normalizeTransportVoucher(voucher);
+  if (!safeVoucher) return null;
+
+  return (
+    <section className="mb-6" aria-labelledby="transport-voucher-heading">
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h2 id="transport-voucher-heading" className="text-xl font-semibold text-gray-700 dark:text-gray-300">
+            Transport Voucher
+          </h2>
+          <div className="text-sm text-gray-500">
+            {safeVoucher.voucherNumber && <span>Voucher {safeVoucher.voucherNumber}</span>}
+            {safeVoucher.version && <span> · Version {safeVoucher.version}</span>}
+            {safeVoucher.releasedAt && <span> · Released {formatPortalDate(safeVoucher.releasedAt)}</span>}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {safeVoucher.previewUrl && (
+            <a
+              href={safeVoucher.previewUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              referrerPolicy="no-referrer"
+              className="inline-flex min-h-10 items-center justify-center rounded-lg bg-red-800 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+            >
+              View / Print voucher
+            </a>
+          )}
+          {safeVoucher.downloadUrl && (
+            <a
+              href={safeVoucher.downloadUrl}
+              download={safeVoucher.fileName}
+              target="_blank"
+              rel="noopener noreferrer"
+              referrerPolicy="no-referrer"
+              className="inline-flex min-h-10 items-center justify-center rounded-lg border border-red-800 px-4 py-2 text-sm font-semibold text-red-800 hover:bg-red-50 dark:text-red-200"
+            >
+              Download
+            </a>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-4 rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-700">
+        {(safeVoucher.arrival || safeVoucher.departure) && (
+          <div className="grid gap-4 md:grid-cols-2">
+            <JourneyCard title="Arrival" details={safeVoucher.arrival} />
+            <JourneyCard title="Departure" details={safeVoucher.departure} />
+          </div>
+        )}
+
+        {safeVoucher.routes.length > 0 && (
+          <div>
+            <h3 className="font-semibold text-gray-800 dark:text-gray-100">Route timeline</h3>
+            <ol className="mt-3 space-y-3">
+              {safeVoucher.routes.map((route, index) => (
+                <li key={route.id} className="relative rounded-lg border border-slate-200 bg-white p-4 pl-11 dark:border-slate-600 dark:bg-gray-800">
+                  <span className="absolute left-3 top-4 flex h-6 w-6 items-center justify-center rounded-full bg-red-800 text-xs font-bold text-white" aria-hidden="true">
+                    {index + 1}
+                  </span>
+                  <h4 className="break-words font-semibold text-gray-800 dark:text-gray-100">{route.label}</h4>
+                  <dl className="mt-2 space-y-1 text-sm text-gray-600 dark:text-gray-300">
+                    {(route.from || route.to) && <div><dt className="sr-only">Route</dt><dd className="break-words">{route.from || 'Pickup'} → {route.to || 'Destination'}</dd></div>}
+                    {route.date && <div><dt className="inline font-semibold">Date: </dt><dd className="inline">{formatPortalDate(route.date)}</dd></div>}
+                    {route.time && <div><dt className="inline font-semibold">Time: </dt><dd className="inline">{route.time}</dd></div>}
+                    {route.vehicleType && <div><dt className="inline font-semibold">Vehicle: </dt><dd className="inline">{route.vehicleType}</dd></div>}
+                    {route.provider?.name && <div><dt className="inline font-semibold">Provider: </dt><dd className="inline">{route.provider.name}</dd></div>}
+                    {route.provider?.phone && <div><dt className="inline font-semibold">Provider contact: </dt><dd className="inline">{route.provider.phone}</dd></div>}
+                    {route.driver?.name && <div><dt className="inline font-semibold">Driver: </dt><dd className="inline">{route.driver.name}</dd></div>}
+                    {route.driver?.phone && <div><dt className="inline font-semibold">Driver contact: </dt><dd className="inline">{route.driver.phone}</dd></div>}
+                  </dl>
+                  {route.publicNotes && <p className="mt-2 whitespace-pre-line break-words text-sm text-gray-600 dark:text-gray-300">{route.publicNotes}</p>}
+                </li>
+              ))}
+            </ol>
+          </div>
+        )}
+
+        {(safeVoucher.provider || safeVoucher.driver) && (
+          <div className="grid gap-4 md:grid-cols-2">
+            <ContactCard title="Transport provider" contact={safeVoucher.provider} />
+            <ContactCard title="Driver" contact={safeVoucher.driver} />
+          </div>
+        )}
+
+        {safeVoucher.publicNotes && (
+          <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-600 dark:bg-gray-800">
+            <h3 className="font-semibold text-gray-800 dark:text-gray-100">Public notes</h3>
+            <p className="mt-2 whitespace-pre-line break-words text-sm text-gray-600 dark:text-gray-300">{safeVoucher.publicNotes}</p>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/services/packageErrorResolver.js
+++ b/src/services/packageErrorResolver.js
@@ -1,0 +1,36 @@
+const ACCESS_ERROR_MESSAGES = {
+  400: 'Check the package reference and lead passenger surname, then try again.',
+  404: 'Package details do not match. Check the lead passenger surname and reference.',
+  410: 'Your document access has expired. Contact your agent to renew access.',
+  429: 'Too many attempts. Please wait before trying again.',
+  500: 'The package service is temporarily unavailable. Please try again shortly.',
+  502: 'The package service is temporarily unavailable. Please try again shortly.',
+  503: 'The package service is temporarily unavailable. Please try again shortly.',
+  504: 'The package service is temporarily unavailable. Please try again shortly.'
+};
+
+const TOKEN_ERROR_MESSAGES = {
+  ...ACCESS_ERROR_MESSAGES,
+  400: 'This package access link is invalid. Contact your agent for a new link.',
+  404: 'Package documents are not currently available. Contact your agent.',
+  429: 'Too many requests. Please wait before trying this link again.'
+};
+
+/**
+ * Convert an API failure to calm customer copy.
+ * Use context `token` for direct package links and `access` for surname login.
+ */
+export const packageErrorResolver = (status, message, context = 'access') => {
+  const errorMap = context === 'token' ? TOKEN_ERROR_MESSAGES : ACCESS_ERROR_MESSAGES;
+  const numericStatus = Number(status);
+
+  if (numericStatus && errorMap[numericStatus]) return errorMap[numericStatus];
+  if (typeof message === 'string' && message.trim()) return message;
+
+  return context === 'token'
+    ? 'Package documents are not currently available. Contact your agent.'
+    : ACCESS_ERROR_MESSAGES[404];
+};
+
+export const getPackageErrorMessage = (error, context = 'access') =>
+  packageErrorResolver(error?.status, error?.message, context);

--- a/src/services/packagePortalApi.js
+++ b/src/services/packagePortalApi.js
@@ -1,0 +1,159 @@
+const ACCESS_ENDPOINT = '/api/package-access';
+const DATA_ENDPOINT = '/api/package-data';
+const SESSION_ENDPOINT = '/api/package-session';
+
+const DEFAULT_ACCESS_ERROR = 'Package details do not match. Check the lead passenger surname and reference.';
+const DEFAULT_DATA_ERROR = 'Package documents are not currently available. Contact your agent.';
+const DEFAULT_SERVICE_ERROR = 'The package service is temporarily unavailable. Please try again shortly.';
+
+/**
+ * Error returned by the same-origin package portal API.
+ * `status` is zero for a network failure. `retryAfter` is seconds, when supplied.
+ */
+export class PackagePortalApiError extends Error {
+  constructor(message, { status = 0, retryAfter = null, code = null, cause } = {}) {
+    super(message || DEFAULT_SERVICE_ERROR, cause ? { cause } : undefined);
+    this.name = 'PackagePortalApiError';
+    this.status = Number.isFinite(Number(status)) ? Number(status) : 0;
+    this.retryAfter = Number.isFinite(Number(retryAfter)) ? Math.max(0, Math.ceil(Number(retryAfter))) : null;
+    this.code = code || null;
+  }
+}
+
+export function isPackagePortalApiError(error) {
+  return error instanceof PackagePortalApiError || error?.name === 'PackagePortalApiError';
+}
+
+function parseRetryAfter(value) {
+  if (!value) return null;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) return Math.max(0, Math.ceil(seconds));
+
+  const retryDate = new Date(value);
+  if (Number.isNaN(retryDate.getTime())) return null;
+  return Math.max(0, Math.ceil((retryDate.getTime() - Date.now()) / 1000));
+}
+
+async function readJsonSafely(response) {
+  let text = '';
+  try {
+    text = await response.text();
+  } catch (_error) {
+    return { payload: {}, isEmpty: true, isInvalid: true };
+  }
+
+  if (!text.trim()) return { payload: {}, isEmpty: true, isInvalid: false };
+
+  try {
+    const payload = JSON.parse(text);
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+      return { payload: {}, isEmpty: false, isInvalid: true };
+    }
+    return { payload, isEmpty: false, isInvalid: false };
+  } catch (_error) {
+    return { payload: {}, isEmpty: false, isInvalid: true };
+  }
+}
+
+async function requestJson(url, options, fallbackMessage, { allowEmpty = false } = {}) {
+  let response;
+  try {
+    response = await fetch(url, {
+      credentials: 'same-origin',
+      cache: 'no-store',
+      ...options
+    });
+  } catch (error) {
+    if (error?.name === 'AbortError') throw error;
+    throw new PackagePortalApiError(DEFAULT_SERVICE_ERROR, { status: 0, cause: error });
+  }
+
+  const parsed = await readJsonSafely(response);
+  const payload = parsed.payload;
+  if (!response.ok) {
+    throw new PackagePortalApiError(
+      typeof payload.error === 'string' && payload.error.trim() ? payload.error : fallbackMessage,
+      {
+        status: response.status,
+        retryAfter: parseRetryAfter(response.headers.get('Retry-After')),
+        code: typeof payload.code === 'string' ? payload.code : null
+      }
+    );
+  }
+
+  if (parsed.isInvalid || (parsed.isEmpty && !allowEmpty)) {
+    throw new PackagePortalApiError(DEFAULT_SERVICE_ERROR, { status: 502, code: 'INVALID_JSON_RESPONSE' });
+  }
+
+  const sessionHeader = response.headers.get('X-Package-Session');
+  if (
+    payload && typeof payload === 'object' &&
+    payload.sessionEstablished === undefined &&
+    ['1', 'true', 'established'].includes(String(sessionHeader || '').toLowerCase())
+  ) {
+    return { ...payload, sessionEstablished: true };
+  }
+
+  return payload;
+}
+
+/**
+ * Resolve reference/surname access. The endpoint may establish an HttpOnly cookie
+ * and return `sessionEstablished: true`, or return a phase-one bearer token.
+ */
+export function resolvePackageAccess(reference, lastName, { signal } = {}) {
+  return requestJson(ACCESS_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ reference, lastName }),
+    signal
+  }, DEFAULT_ACCESS_ERROR);
+}
+
+/**
+ * Load current package data. Supplying `token` sends it in an Authorization header,
+ * never in the URL. Omit it when an HttpOnly package session cookie exists.
+ */
+export function loadPackageData(token = null, { signal } = {}) {
+  const headers = { Accept: 'application/json' };
+  const credential = typeof token === 'string' ? token.trim() : '';
+  if (credential) headers.Authorization = `Bearer ${credential}`;
+
+  return requestJson(DATA_ENDPOINT, {
+    method: 'GET',
+    headers,
+    signal
+  }, DEFAULT_DATA_ERROR);
+}
+
+/**
+ * Optional hardened flow: exchange a direct-route bearer token for an HttpOnly
+ * session cookie. The backend may return an empty JSON object.
+ */
+export function exchangePackageSession(token, { signal, endpoint = SESSION_ENDPOINT } = {}) {
+  const credential = typeof token === 'string' ? token.trim() : '';
+  if (!credential) {
+    return Promise.reject(new PackagePortalApiError('Invalid package access token.', { status: 400 }));
+  }
+
+  return requestJson(endpoint, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${credential}`
+    },
+    signal
+  }, DEFAULT_DATA_ERROR);
+}
+
+/** Clear the optional HttpOnly package session cookie on logout. */
+export function logoutPackageSession({ signal, endpoint = SESSION_ENDPOINT } = {}) {
+  return requestJson(endpoint, {
+    method: 'DELETE',
+    headers: { Accept: 'application/json' },
+    signal
+  }, DEFAULT_SERVICE_ERROR, { allowEmpty: true });
+}

--- a/src/types/packagePortal.js
+++ b/src/types/packagePortal.js
@@ -1,0 +1,125 @@
+// Runtime-free JSDoc contracts shared by the customer package portal.
+
+/**
+ * @typedef {'pt_portal'|'legacy_firebase'} PortalSource
+ * @typedef {'pdf'|'image'|'html'|'download'} PortalDocumentKind
+ *
+ * @typedef {Object} PortalDocument
+ * @property {string} id
+ * @property {'flight'|'hotel'|'transport'|'visa'|'e_sim'|'insurance'|'invoice'|'other'} category
+ * @property {string} title
+ * @property {string} file_name
+ * @property {string|number|null} file_size
+ * @property {string} file_type
+ * @property {string|null} released_at
+ * @property {string} public_notes
+ * @property {string|null} signed_url Download URL; never derive a public storage URL.
+ * @property {string|null} preview_url Inline URL; deliberately not inferred from signed_url.
+ *
+ * @typedef {Object} PortalChecklistItem
+ * @property {string} id
+ * @property {string} label
+ * @property {string} status
+ * @property {boolean} completed Read-only for PT packages.
+ *
+ * @typedef {Object} PortalInvoiceLine
+ * @property {string} id
+ * @property {string} description
+ * @property {string|number|null} quantity
+ * @property {string|number|null} soldAmount
+ * @property {string|number|null} lineTotal
+ *
+ * @typedef {Object} PortalInvoice
+ * @property {string} invoiceNumber
+ * @property {string} version
+ * @property {string} currency
+ * @property {string|null} releasedAt
+ * @property {string|null} dueDate
+ * @property {string} customerTerms
+ * @property {string|number|null} subtotal
+ * @property {string|number|null} discount
+ * @property {string|number|null} total
+ * @property {string|number|null} amountPaid
+ * @property {string|number|null} balanceDue
+ * @property {PortalInvoiceLine[]} lines
+ *
+ * @typedef {Object} PortalContact
+ * @property {string} name
+ * @property {string} phone
+ * @property {string} email
+ * @property {string} whatsApp
+ *
+ * @typedef {Object} PortalJourneyDetails
+ * @property {string} summary
+ * @property {string|null} date
+ * @property {string} time
+ * @property {string} flightNumber
+ * @property {string} airport
+ * @property {string} terminal
+ * @property {string} location
+ *
+ * @typedef {Object} PortalTransportRoute
+ * @property {string} id
+ * @property {string} label
+ * @property {string} from
+ * @property {string} to
+ * @property {string|null} date
+ * @property {string} time
+ * @property {string} vehicleType
+ * @property {string} publicNotes
+ * @property {PortalContact|null} provider
+ * @property {PortalContact|null} driver
+ *
+ * @typedef {Object} PortalTransportVoucher
+ * @property {string} voucherNumber
+ * @property {string} version
+ * @property {string|null} releasedAt
+ * @property {string} publicNotes
+ * @property {PortalJourneyDetails|null} arrival
+ * @property {PortalJourneyDetails|null} departure
+ * @property {PortalTransportRoute[]} routes
+ * @property {PortalContact|null} provider
+ * @property {PortalContact|null} driver
+ * @property {string|null} previewUrl
+ * @property {string|null} downloadUrl
+ * @property {string} fileName
+ *
+ * @typedef {Object} PortalPackage
+ * @property {'pt_portal'} source
+ * @property {string} reference
+ * @property {string} customerName
+ * @property {string} packageType
+ * @property {string} destination
+ * @property {string|null} departureDate
+ * @property {string|null} returnDate
+ * @property {string|null} accessExpiresAt
+ * @property {string} statusLabel
+ * @property {Record<string, string|number|boolean>} publicSummary
+ * @property {PortalDocument[]} documents
+ * @property {PortalTransportVoucher|null} transportVoucher
+ * @property {PortalInvoice|null} releasedInvoice
+ * @property {PortalChecklistItem[]} checklist
+ * @property {{customerEmail: string, customerName: string}} keyInformation
+ * @property {number|null} signedUrlExpiresIn
+ * @property {string} loadedAt ISO time when URLs were loaded.
+ *
+ * @typedef {Object} PackageAuthenticationResult
+ * @property {PortalPackage|Object} package Normalized PT package or preserved legacy customer.
+ * @property {string|null} credential Phase-one bearer token; keep in React state only.
+ * @property {boolean} sessionEstablished True when an HttpOnly package cookie exists.
+ *
+ * @callback PackageAuthenticatedCallback
+ * @param {PackageAuthenticationResult} result
+ * @returns {void|Promise<void>}
+ *
+ * @callback RefreshPortalDocumentCallback
+ * @param {PortalDocument} document
+ * @param {{reason: 'preview-error'|'customer-request'}} context
+ * @returns {PortalDocument|Promise<PortalDocument>}
+ *
+ * @callback PortalDocumentActionCallback
+ * @param {PortalDocument} document
+ * @returns {void|Promise<void>}
+ */
+
+export const packagePortalTypeDefinitions = null;

--- a/src/utils/packagePortal.js
+++ b/src/utils/packagePortal.js
@@ -1,0 +1,196 @@
+const SAFE_EXTERNAL_PROTOCOLS = new Set(['http:', 'https:']);
+
+const CATEGORY_ALIASES = {
+  flight: 'flight',
+  flights: 'flight',
+  hotel: 'hotel',
+  hotels: 'hotel',
+  transport: 'transport',
+  transportation: 'transport',
+  visa: 'visa',
+  visas: 'visa',
+  e_sim: 'e_sim',
+  esim: 'e_sim',
+  'e-sim': 'e_sim',
+  insurance: 'insurance',
+  invoice: 'invoice',
+  invoices: 'invoice',
+  other: 'other',
+  others: 'other'
+};
+
+export const DOCUMENT_KINDS = Object.freeze({
+  PDF: 'pdf',
+  IMAGE: 'image',
+  HTML: 'html',
+  DOWNLOAD: 'download'
+});
+
+export function isRecord(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function cleanText(value, fallback = '', maxLength = 2000) {
+  if (value === null || value === undefined) return fallback;
+  if (!['string', 'number', 'boolean'].includes(typeof value)) return fallback;
+
+  const text = String(value).trim();
+  if (!text) return fallback;
+  return text.slice(0, maxLength);
+}
+
+export function firstValue(sources, keys, fallback = null) {
+  for (const source of sources) {
+    if (!isRecord(source)) continue;
+    for (const key of keys) {
+      const value = source[key];
+      if (value !== undefined && value !== null && value !== '') return value;
+    }
+  }
+  return fallback;
+}
+
+export function isExplicitFalse(value) {
+  return value === false || value === 0 || ['false', '0', 'no'].includes(String(value).toLowerCase());
+}
+
+export function isExplicitTrue(value) {
+  return value === true || value === 1 || ['true', '1', 'yes'].includes(String(value).toLowerCase());
+}
+
+export function safeExternalUrl(value) {
+  const candidate = cleanText(value, '', 4096);
+  if (!candidate) return null;
+
+  try {
+    const baseUrl = typeof window !== 'undefined' && window.location?.origin
+      ? window.location.origin
+      : 'https://bookings.piyamtravel.com';
+    const parsed = new URL(candidate, baseUrl);
+    const isLocalHost = ['localhost', '127.0.0.1', '::1', '[::1]'].includes(parsed.hostname);
+    if (
+      !SAFE_EXTERNAL_PROTOCOLS.has(parsed.protocol) ||
+      (parsed.protocol !== 'https:' && !isLocalHost) ||
+      parsed.username ||
+      parsed.password
+    ) return null;
+    return parsed.href;
+  } catch (_error) {
+    return null;
+  }
+}
+
+export function normalizeDocumentCategory(value) {
+  const normalized = cleanText(value, 'other', 80)
+    .toLowerCase()
+    .replace(/\s+/g, '_');
+
+  return CATEGORY_ALIASES[normalized] || 'other';
+}
+
+export function isTravelDocumentsCategory(value) {
+  const normalized = cleanText(value, '', 80)
+    .toLowerCase()
+    .replace(/[\s-]+/g, '_');
+
+  return normalized === 'travel_documents' || normalized === 'traveldocuments';
+}
+
+export function getDocumentExtension(document) {
+  const candidates = [document?.file_name, document?.title, document?.preview_url, document?.signed_url];
+
+  for (const candidate of candidates) {
+    const text = cleanText(candidate, '', 4096).split(/[?#]/, 1)[0];
+    const match = text.toLowerCase().match(/\.([a-z0-9]{1,10})$/);
+    if (match) return match[1];
+  }
+
+  return '';
+}
+
+/**
+ * Classifies only the formats the customer portal can safely preview.
+ * HTML is previewable only for the controlled transport-voucher flow.
+ */
+export function classifyPortalDocument(document) {
+  const mimeType = cleanText(document?.file_type, '', 200).toLowerCase().split(';', 1)[0];
+  const extension = getDocumentExtension(document);
+  const category = normalizeDocumentCategory(document?.category);
+
+  if (mimeType === 'application/pdf' || mimeType === 'pdf' || extension === 'pdf') {
+    return DOCUMENT_KINDS.PDF;
+  }
+
+  if (
+    ['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'jpg', 'jpeg', 'png', 'webp'].includes(mimeType) ||
+    ['jpg', 'jpeg', 'png', 'webp'].includes(extension)
+  ) {
+    return DOCUMENT_KINDS.IMAGE;
+  }
+
+  const isHtml = ['text/html', 'application/xhtml+xml', 'html', 'htm'].includes(mimeType) ||
+    ['html', 'htm'].includes(extension);
+
+  if (isHtml && category === 'transport') return DOCUMENT_KINDS.HTML;
+  return DOCUMENT_KINDS.DOWNLOAD;
+}
+
+export function formatFileSize(value) {
+  if (value === null || value === undefined || value === '') return 'File';
+  if (typeof value === 'string' && /[a-z]/i.test(value)) return cleanText(value, 'File', 80);
+
+  const bytes = Number(value);
+  if (!Number.isFinite(bytes) || bytes < 0) return 'File';
+  if (bytes < 1024) return `${Math.round(bytes)} B`;
+
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let size = bytes / 1024;
+  let unitIndex = 0;
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+
+  return `${new Intl.NumberFormat('en-GB', { maximumFractionDigits: size < 10 ? 1 : 0 }).format(size)} ${units[unitIndex]}`;
+}
+
+export function formatPortalDate(value, options = {}) {
+  if (!value) return options.fallback || 'Not supplied';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return cleanText(value, options.fallback || 'Not supplied', 100);
+
+  return new Intl.DateTimeFormat('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    ...(options.includeTime ? { hour: '2-digit', minute: '2-digit' } : {})
+  }).format(date);
+}
+
+export function formatMoney(value, currency = 'GBP') {
+  if (value === null || value === undefined || value === '') return null;
+  const amount = Number(value);
+  if (!Number.isFinite(amount)) return cleanText(value, '', 80) || null;
+
+  const normalizedCurrency = /^[A-Z]{3}$/.test(cleanText(currency, '', 3).toUpperCase())
+    ? cleanText(currency, '', 3).toUpperCase()
+    : 'GBP';
+
+  try {
+    return new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency: normalizedCurrency,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2
+    }).format(amount);
+  } catch (_error) {
+    return `${normalizedCurrency} ${amount.toFixed(2)}`;
+  }
+}
+
+export function formatQuantity(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const quantity = Number(value);
+  if (!Number.isFinite(quantity)) return cleanText(value, '', 40) || null;
+  return new Intl.NumberFormat('en-GB', { maximumFractionDigits: 2 }).format(quantity);
+}

--- a/test/access-session-handlers.test.js
+++ b/test/access-session-handlers.test.js
@@ -1,0 +1,288 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createPackageAccessHandler } from '../api/package-access.js';
+import { createPackageDataHandler, resolveRequestToken } from '../api/package-data.js';
+import { createPackageSessionHandler } from '../api/package-session.js';
+import { HttpError } from '../server/http.js';
+import { createPackageAccessResolver } from '../server/package-access-resolver.js';
+import {
+  clearPackageSessionCookie,
+  decryptPackageSession,
+  encryptPackageSession,
+  isPackageSessionConfigured,
+  PACKAGE_SESSION_COOKIE,
+  parseCookies,
+  setPackageSessionCookie
+} from '../server/package-session.js';
+import { createMockResponse, SESSION_ENV } from './helpers.js';
+
+const TOKEN = 'opaque-token-123';
+
+test('access resolver never touches legacy storage when PT-Portal succeeds', async () => {
+  let legacyCalls = 0;
+  const resolve = createPackageAccessResolver({
+    portalClientFactory: () => ({
+      accessPackage: async (reference, lastName) => {
+        assert.equal(reference, 'PT-H29GPX');
+        assert.equal(lastName, 'Smith');
+        return { found: true, token: TOKEN };
+      }
+    }),
+    legacyLookup: async () => {
+      legacyCalls += 1;
+      return null;
+    }
+  });
+
+  assert.deepEqual(await resolve('h29gpx', ' Smith '), {
+    source: 'pt_portal',
+    reference: 'PT-H29GPX',
+    token: TOKEN,
+    customer: null
+  });
+  assert.equal(legacyCalls, 0);
+});
+
+test('access resolver performs legacy fallback only for PT not-found result', async () => {
+  const customer = { id: 'legacy-1', referenceNumber: 'PT-H29GPX' };
+  const calls = [];
+  const resolve = createPackageAccessResolver({
+    portalClientFactory: () => ({ accessPackage: async () => ({ found: false, token: null }) }),
+    legacyLookup: async (...args) => {
+      calls.push(args);
+      return customer;
+    }
+  });
+
+  assert.deepEqual(await resolve('PT-H29GPX', 'Smith'), {
+    source: 'legacy_firebase',
+    reference: 'PT-H29GPX',
+    token: null,
+    customer
+  });
+  assert.deepEqual(calls, [['PT-H29GPX', 'Smith']]);
+});
+
+test('access resolver does not downgrade PT errors to legacy lookups', async () => {
+  for (const status of [400, 410, 429, 503, 504]) {
+    let legacyCalls = 0;
+    const expected = new HttpError(status, 'PT failure');
+    const resolve = createPackageAccessResolver({
+      portalClientFactory: () => ({ accessPackage: async () => { throw expected; } }),
+      legacyLookup: async () => {
+        legacyCalls += 1;
+        return { id: 'must-not-load' };
+      }
+    });
+
+    await assert.rejects(resolve('PT-H29GPX', 'Smith'), error => error === expected);
+    assert.equal(legacyCalls, 0);
+  }
+});
+
+test('invalid access input is rejected before either data source is created', async () => {
+  let portalFactoryCalls = 0;
+  let legacyCalls = 0;
+  const resolve = createPackageAccessResolver({
+    portalClientFactory: () => {
+      portalFactoryCalls += 1;
+      return { accessPackage: async () => ({ found: false }) };
+    },
+    legacyLookup: async () => { legacyCalls += 1; }
+  });
+
+  await assert.rejects(resolve('bad', ''), error => error.status === 400 && error.code === 'INVALID_ACCESS_INPUT');
+  assert.equal(portalFactoryCalls, 0);
+  assert.equal(legacyCalls, 0);
+});
+
+test('secure package sessions round-trip and reject expiration or tampering', () => {
+  const now = Date.parse('2026-08-08T12:00:00Z');
+  assert.equal(isPackageSessionConfigured({}), false);
+  assert.equal(isPackageSessionConfigured(SESSION_ENV), true);
+
+  const encrypted = encryptPackageSession(TOKEN, { env: SESSION_ENV, now, ttlSeconds: 300 });
+  assert.deepEqual(decryptPackageSession(encrypted, { env: SESSION_ENV, now: now + 1_000 }), {
+    token: TOKEN,
+    expiresAt: now + 300_000
+  });
+  assert.equal(decryptPackageSession(encrypted, { env: SESSION_ENV, now: now + 300_000 }), null);
+  const tamperedParts = encrypted.split('.');
+  tamperedParts[2] = `${tamperedParts[2][0] === 'A' ? 'B' : 'A'}${tamperedParts[2].slice(1)}`;
+  assert.equal(decryptPackageSession(tamperedParts.join('.'), { env: SESSION_ENV, now }), null);
+  assert.equal(decryptPackageSession(encrypted, { env: { PACKAGE_PORTAL_SESSION_SECRET: `${SESSION_ENV.PACKAGE_PORTAL_SESSION_SECRET}x` }, now }), null);
+});
+
+test('cookie helpers use the secure __Host contract and preserve existing cookies', () => {
+  assert.deepEqual({ ...parseCookies('first=one; duplicate=old; duplicate=new; encoded=a.b-c_d') }, {
+    first: 'one',
+    duplicate: 'old',
+    encoded: 'a.b-c_d'
+  });
+  assert.deepEqual({ ...parseCookies(null) }, {});
+
+  const res = createMockResponse();
+  res.setHeader('Set-Cookie', 'existing=value');
+  assert.equal(setPackageSessionCookie(res, TOKEN, { env: SESSION_ENV, ttlSeconds: 300 }), true);
+  clearPackageSessionCookie(res);
+
+  const cookies = res.getHeader('Set-Cookie');
+  assert.equal(Array.isArray(cookies), true);
+  assert.equal(cookies.length, 3);
+  assert.match(cookies[1], new RegExp(`^${PACKAGE_SESSION_COOKIE}=`));
+  assert.match(cookies[1], /Path=\/; Max-Age=300; HttpOnly; Secure; SameSite=Lax/);
+  assert.match(cookies[2], new RegExp(`^${PACKAGE_SESSION_COOKIE}=;`));
+  assert.match(cookies[2], /Max-Age=0/);
+});
+
+test('access handler returns a bearer token only when encrypted sessions are unavailable', async () => {
+  const resolver = async () => ({ source: 'pt_portal', token: TOKEN });
+
+  const withoutSession = createMockResponse();
+  await createPackageAccessHandler({ resolver, env: {} })(
+    { method: 'POST', body: { reference: 'H29GPX', lastName: 'Smith' } },
+    withoutSession
+  );
+  assert.equal(withoutSession.statusCode, 200);
+  assert.deepEqual(withoutSession.body, {
+    source: 'pt_portal',
+    sessionEstablished: false,
+    token: TOKEN
+  });
+  assert.equal(withoutSession.getHeader('Set-Cookie'), undefined);
+
+  const withSession = createMockResponse();
+  await createPackageAccessHandler({ resolver, env: SESSION_ENV })(
+    { method: 'POST', body: { reference: 'H29GPX', lastName: 'Smith' } },
+    withSession
+  );
+  assert.equal(withSession.statusCode, 200);
+  assert.deepEqual(withSession.body, { source: 'pt_portal', sessionEstablished: true });
+  assert.match(withSession.getHeader('Set-Cookie'), new RegExp(`^${PACKAGE_SESSION_COOKIE}=`));
+  assert.equal(withSession.body.token, undefined);
+});
+
+test('access handler clears stale package sessions for a legacy customer', async () => {
+  const customer = { id: 'legacy-1' };
+  const res = createMockResponse();
+  await createPackageAccessHandler({
+    resolver: async () => ({ source: 'legacy_firebase', customer }),
+    env: SESSION_ENV
+  })({ method: 'POST', body: { reference: 'H29GPX', lastName: 'Smith' } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, { source: 'legacy_firebase', customer });
+  assert.match(res.getHeader('Set-Cookie'), /Max-Age=0/);
+});
+
+test('request token resolution enforces explicit token consistency and priority', () => {
+  const session = encryptPackageSession('cookie-token-123', { env: SESSION_ENV });
+  const cookieHeader = `${PACKAGE_SESSION_COOKIE}=${session}`;
+
+  assert.deepEqual(resolveRequestToken({
+    headers: { authorization: `Bearer ${TOKEN}`, cookie: cookieHeader },
+    query: {}
+  }, SESSION_ENV), { token: TOKEN, source: 'bearer' });
+
+  assert.deepEqual(resolveRequestToken({
+    headers: { cookie: cookieHeader },
+    query: { token: 'query-token-123' }
+  }, SESSION_ENV), { token: 'query-token-123', source: 'query' });
+
+  assert.deepEqual(resolveRequestToken({ headers: { cookie: cookieHeader }, query: {} }, SESSION_ENV), {
+    token: 'cookie-token-123',
+    source: 'cookie'
+  });
+
+  assert.throws(
+    () => resolveRequestToken({
+      headers: { authorization: `Bearer ${TOKEN}` },
+      query: { token: 'different-token-123' }
+    }, SESSION_ENV),
+    error => error.status === 400 && error.code === 'CONFLICTING_TOKENS'
+  );
+});
+
+test('data handler supports deprecated query tokens without putting secrets in its response', async () => {
+  const res = createMockResponse();
+  let loadedToken;
+  await createPackageDataHandler({
+    env: {},
+    portalClientFactory: () => ({
+      loadPackage: async token => {
+        loadedToken = token;
+        return { package: { package_reference: 'PT-H29GPX' }, documents: [] };
+      }
+    })
+  })({ method: 'GET', headers: {}, query: { token: TOKEN } }, res);
+
+  assert.equal(loadedToken, TOKEN);
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.getHeader('Deprecation'), 'true');
+  assert.equal(res.body.sessionEstablished, false);
+  assert.equal(JSON.stringify(res.body).includes(TOKEN), false);
+});
+
+test('data handler establishes a cookie from bearer auth and rejects conflicts', async () => {
+  const handler = createPackageDataHandler({
+    env: SESSION_ENV,
+    portalClientFactory: () => ({ loadPackage: async () => ({ package: {}, documents: [] }) })
+  });
+
+  const success = createMockResponse();
+  await handler({ method: 'GET', headers: { authorization: `Bearer ${TOKEN}` }, query: {} }, success);
+  assert.equal(success.statusCode, 200);
+  assert.equal(success.body.sessionEstablished, true);
+  assert.match(success.getHeader('Set-Cookie'), new RegExp(`^${PACKAGE_SESSION_COOKIE}=`));
+
+  const conflict = createMockResponse();
+  await handler({
+    method: 'GET',
+    headers: { authorization: `Bearer ${TOKEN}` },
+    query: { token: 'different-token-123' }
+  }, conflict);
+  assert.equal(conflict.statusCode, 400);
+  assert.deepEqual(conflict.body, { error: 'Conflicting package access tokens were supplied.' });
+});
+
+test('session endpoint validates the token upstream before setting a cookie and DELETE clears it', async () => {
+  let loadCalls = 0;
+  const handler = createPackageSessionHandler({
+    env: SESSION_ENV,
+    portalClientFactory: () => ({
+      loadPackage: async token => {
+        loadCalls += 1;
+        assert.equal(token, TOKEN);
+        return { package: { package_reference: 'PT-H29GPX' }, documents: [] };
+      }
+    })
+  });
+
+  const post = createMockResponse();
+  await handler({ method: 'POST', headers: { authorization: `Bearer ${TOKEN}` } }, post);
+  assert.equal(post.statusCode, 200);
+  assert.equal(post.body.sessionEstablished, true);
+  assert.equal(loadCalls, 1);
+  assert.match(post.getHeader('Set-Cookie'), new RegExp(`^${PACKAGE_SESSION_COOKIE}=`));
+
+  const remove = createMockResponse();
+  await handler({ method: 'DELETE', headers: {} }, remove);
+  assert.equal(remove.statusCode, 200);
+  assert.deepEqual(remove.body, { sessionEstablished: false });
+  assert.match(remove.getHeader('Set-Cookie'), /Max-Age=0/);
+  assert.equal(loadCalls, 1);
+});
+
+test('handlers reject unsupported methods with an Allow header', async () => {
+  for (const [handler, req, allowed] of [
+    [createPackageAccessHandler({ resolver: async () => null }), { method: 'GET' }, 'POST'],
+    [createPackageDataHandler({ portalClientFactory: () => ({}) }), { method: 'POST' }, 'GET'],
+    [createPackageSessionHandler({ portalClientFactory: () => ({}) }), { method: 'PATCH' }, 'POST, DELETE']
+  ]) {
+    const res = createMockResponse();
+    await handler({ headers: {}, query: {}, ...req }, res);
+    assert.equal(res.statusCode, 405);
+    assert.equal(res.getHeader('Allow'), allowed);
+  }
+});

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+
+export const SESSION_ENV = Object.freeze({
+  PACKAGE_PORTAL_SESSION_SECRET: 'test-only-session-secret-that-is-at-least-32-characters'
+});
+
+export function jsonResponse(payload, init = {}) {
+  const headers = new Headers(init.headers);
+  if (!headers.has('content-type')) headers.set('content-type', 'application/json');
+  return new Response(JSON.stringify(payload), { ...init, headers });
+}
+
+export function createMockResponse() {
+  const headers = new Map();
+
+  return {
+    statusCode: null,
+    body: undefined,
+    setHeader(name, value) {
+      headers.set(String(name).toLowerCase(), value);
+    },
+    getHeader(name) {
+      return headers.get(String(name).toLowerCase());
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+export async function withMockedFetch(fetchImpl, operation) {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = fetchImpl;
+  try {
+    return await operation();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+export function assertHttpError(error, { status, code, retryAfter } = {}) {
+  assert.equal(error?.name, 'HttpError');
+  if (status !== undefined) assert.equal(error.status, status);
+  if (code !== undefined) assert.equal(error.code, code);
+  if (retryAfter !== undefined) assert.equal(error.retryAfter, retryAfter);
+  return true;
+}

--- a/test/legacy-and-adapters.test.js
+++ b/test/legacy-and-adapters.test.js
@@ -1,0 +1,199 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createLegacyCustomerLookup, sanitizeLegacyCustomer } from '../server/legacy-customer.js';
+import { normalizeLegacyPackage } from '../src/adapters/legacyPackageAdapter.js';
+import {
+  normalizeReleasedInvoice,
+  normalizeTransportVoucher
+} from '../src/adapters/portalReleaseAdapters.js';
+import { normalizePtPortalPackage } from '../src/adapters/ptPortalPackageAdapter.js';
+
+test('legacy customer sanitizer exposes only the historical public contract', () => {
+  const sanitized = sanitizeLegacyCustomer('legacy-1', {
+    firstName: 'Ada',
+    lastName: 'Smith',
+    referenceNumber: 'PT-H29GPX',
+    internalNotes: 'never public',
+    supplierCost: 123,
+    documents: [
+      { id: 'doc-1', category: 'flight', name: 'Ticket', url: 'https://files.example.test/ticket.pdf', objectKey: 'private/key' },
+      { id: 'doc-2', category: 'hotel', name: 'Unsafe', url: 'javascript:alert(1)' }
+    ],
+    checklist: [{ id: 'check-1', text: 'Passport ready', completed: true, internal: 'secret' }],
+    keyInformation: { customerEmail: 'ada@example.test', agentName: 'Agent', supplierPhone: 'private' },
+    createdAt: new Date('2026-08-01T10:00:00Z')
+  });
+
+  assert.deepEqual(sanitized.documents, [{
+    id: 'doc-1',
+    category: 'flight',
+    name: 'Ticket',
+    url: 'https://files.example.test/ticket.pdf'
+  }]);
+  assert.deepEqual(sanitized.checklist, [{ id: 'check-1', text: 'Passport ready', completed: true }]);
+  assert.equal(sanitized.createdAt, '2026-08-01T10:00:00.000Z');
+  assert.equal(sanitized.internalNotes, undefined);
+  assert.equal(sanitized.supplierCost, undefined);
+  assert.equal(sanitized.keyInformation.supplierPhone, undefined);
+});
+
+test('legacy lookup uses normalized equality filters and sanitizes the selected document', async () => {
+  const calls = [];
+  const snapshot = {
+    empty: false,
+    docs: [{
+      id: 'legacy-1',
+      data: () => ({ firstName: 'Ada', lastName: 'Smith', referenceNumber: 'PT-H29GPX', private: 'hidden' })
+    }]
+  };
+  const query = {
+    where(...args) { calls.push(['where', ...args]); return this; },
+    limit(...args) { calls.push(['limit', ...args]); return this; },
+    async get() { calls.push(['get']); return snapshot; }
+  };
+  const database = {
+    collection(name) { calls.push(['collection', name]); return query; }
+  };
+  const lookup = createLegacyCustomerLookup({ getDatabase: async () => database });
+
+  const customer = await lookup('PT-H29GPX', ' Smith ');
+  assert.equal(customer.id, 'legacy-1');
+  assert.equal(customer.private, undefined);
+  assert.deepEqual(calls, [
+    ['collection', 'customers'],
+    ['where', 'referenceNumber', '==', 'PT-H29GPX'],
+    ['where', 'lastName_lowercase', '==', 'smith'],
+    ['limit', 1],
+    ['get']
+  ]);
+});
+
+test('PT adapter accepts omitted release flags and rejects explicit hidden, draft, or travel bundles', () => {
+  const normalized = normalizePtPortalPackage({
+    package: {
+      package_reference: 'PT-H29GPX',
+      customer_name: 'Ada Smith',
+      customer_email: 'ada@example.test',
+      destination: 'Istanbul'
+    },
+    documents: [
+      { id: 'visible', category: 'flights', title: 'Ticket', signed_url: 'https://files.example.test/ticket.pdf' },
+      { id: 'hidden', category: 'hotel', title: 'Hotel', customer_visible: false, signed_url: 'https://files.example.test/hotel.pdf' },
+      { id: 'draft', category: 'visa', title: 'Visa', status: 'draft', signed_url: 'https://files.example.test/visa.pdf' },
+      { id: 'bundle', category: 'travel-documents', title: 'Bundle', signed_url: 'https://files.example.test/bundle.pdf' }
+    ]
+  });
+
+  assert.equal(normalized.source, 'pt_portal');
+  assert.equal(normalized.reference, 'PT-H29GPX');
+  assert.equal(normalized.documents.length, 1);
+  assert.deepEqual(normalized.documents[0], {
+    id: 'visible',
+    category: 'flight',
+    title: 'Ticket',
+    file_name: 'Ticket',
+    file_size: null,
+    file_type: '',
+    released_at: null,
+    public_notes: '',
+    signed_url: 'https://files.example.test/ticket.pdf',
+    preview_url: null,
+    status: 'released',
+    customer_visible: true
+  });
+});
+
+test('legacy adapter preserves legacy data while adding normalized portal aliases', () => {
+  const raw = {
+    id: 'legacy-1',
+    firstName: 'Ada',
+    lastName: 'Smith',
+    referenceNumber: 'PT-OLD123',
+    customLegacyFlag: true,
+    documents: [{ id: 'd1', category: 'Hotels', name: 'Hotel voucher', url: 'https://files.example.test/hotel.pdf' }]
+  };
+  const normalized = normalizeLegacyPackage(raw);
+
+  assert.equal(normalized.source, 'legacy_firebase');
+  assert.equal(normalized.customerName, 'Ada Smith');
+  assert.equal(normalized.customLegacyFlag, true);
+  assert.equal(normalized.documents, raw.documents);
+  assert.equal(normalized.portalDocuments.length, 1);
+  assert.equal(normalized.portalDocuments[0].category, 'hotel');
+  assert.equal(normalized.portalDocuments[0].signed_url, 'https://files.example.test/hotel.pdf');
+});
+
+test('released invoice adapter is an explicit allowlist at invoice and line level', () => {
+  const invoice = normalizeReleasedInvoice({
+    status: 'released',
+    invoice_number: 'INV-42',
+    currency: 'gbp',
+    total: 1_500,
+    supplier_cost: 900,
+    commission: 100,
+    internal_notes: 'private note',
+    lines: [{
+      id: 'line-1',
+      customer_description: 'Travel package',
+      quantity: 1,
+      sold_amount: 1_500,
+      line_total: 1_500,
+      net_cost: 900,
+      margin: 600,
+      supplier: 'Private Supplier'
+    }]
+  });
+
+  assert.deepEqual(Object.keys(invoice).sort(), [
+    'amountPaid', 'balanceDue', 'currency', 'customerTerms', 'discount', 'dueDate',
+    'invoiceNumber', 'lines', 'releasedAt', 'subtotal', 'total', 'version'
+  ].sort());
+  assert.deepEqual(Object.keys(invoice.lines[0]).sort(), [
+    'description', 'id', 'lineTotal', 'quantity', 'soldAmount'
+  ].sort());
+  assert.equal(invoice.invoiceNumber, 'INV-42');
+  assert.equal(invoice.currency, 'GBP');
+  assert.doesNotMatch(JSON.stringify(invoice), /supplier|private note|net_cost|margin/i);
+  assert.equal(normalizeReleasedInvoice({ status: 'draft', invoice_number: 'INV-DRAFT' }), null);
+});
+
+test('transport voucher adapter allowlists journey, contact, route, and URL fields', () => {
+  const voucher = normalizeTransportVoucher({
+    voucher_number: 'TV-42',
+    public_notes: 'Meet at arrivals',
+    supplier_cost: 70,
+    internal_notes: 'private note',
+    provider: { name: 'Public Transfers', phone: '+44 20 0000 0000', booked_cost: 70 },
+    driver: { name: 'Driver Name', phone: '+44 7000 000000', private_id: 'secret-id' },
+    routes: [{
+      id: 'route-1',
+      label: 'Airport to hotel',
+      from: 'Airport',
+      to: 'Hotel',
+      time: '14:30',
+      vehicle_type: 'Minibus',
+      supplier_allocation: 'private allocation',
+      route_cost: 70
+    }],
+    document: {
+      preview_url: 'https://files.example.test/voucher.html',
+      signed_url: 'https://files.example.test/voucher.pdf',
+      file_name: 'voucher.pdf',
+      object_key: 'private/key'
+    }
+  });
+
+  assert.deepEqual(Object.keys(voucher).sort(), [
+    'arrival', 'departure', 'downloadUrl', 'driver', 'fileName', 'previewUrl', 'provider',
+    'publicNotes', 'releasedAt', 'routes', 'version', 'voucherNumber'
+  ].sort());
+  assert.deepEqual(Object.keys(voucher.routes[0]).sort(), [
+    'date', 'driver', 'from', 'id', 'label', 'provider', 'publicNotes', 'time', 'to', 'vehicleType'
+  ].sort());
+  assert.deepEqual(Object.keys(voucher.provider).sort(), ['email', 'name', 'phone', 'whatsApp'].sort());
+  assert.equal(voucher.previewUrl, 'https://files.example.test/voucher.html');
+  assert.equal(voucher.downloadUrl, 'https://files.example.test/voucher.pdf');
+  assert.doesNotMatch(JSON.stringify(voucher), /private|supplier_cost|route_cost|object_key/i);
+  assert.equal(normalizeTransportVoucher({ hidden: true, voucher_number: 'TV-HIDDEN' }), null);
+});

--- a/test/package-portal-client.test.js
+++ b/test/package-portal-client.test.js
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  exchangePackageSession,
+  isPackagePortalApiError,
+  loadPackageData,
+  logoutPackageSession,
+  PackagePortalApiError,
+  resolvePackageAccess
+} from '../src/services/packagePortalApi.js';
+import { jsonResponse, withMockedFetch } from './helpers.js';
+
+const TOKEN = 'opaque-token-123';
+
+test('client posts reference access using same-origin no-store credentials', async () => {
+  let captured;
+  const result = await withMockedFetch(async (url, init) => {
+    captured = { url, init };
+    return jsonResponse({ source: 'pt_portal', token: TOKEN });
+  }, () => resolvePackageAccess('PT-H29GPX', 'Smith'));
+
+  assert.deepEqual(result, { source: 'pt_portal', token: TOKEN });
+  assert.equal(captured.url, '/api/package-access');
+  assert.equal(captured.init.method, 'POST');
+  assert.equal(captured.init.credentials, 'same-origin');
+  assert.equal(captured.init.cache, 'no-store');
+  assert.deepEqual(JSON.parse(captured.init.body), { reference: 'PT-H29GPX', lastName: 'Smith' });
+});
+
+test('client sends package tokens only in Authorization, never in the URL', async () => {
+  let captured;
+  const result = await withMockedFetch(async (url, init) => {
+    captured = { url, init };
+    return jsonResponse({ package: { package_reference: 'PT-H29GPX' }, documents: [] });
+  }, () => loadPackageData(`  ${TOKEN}  `));
+
+  assert.equal(captured.url, '/api/package-data');
+  assert.equal(captured.url.includes(TOKEN), false);
+  assert.equal(captured.init.headers.Authorization, `Bearer ${TOKEN}`);
+  assert.equal(captured.init.credentials, 'same-origin');
+  assert.equal(result.package.package_reference, 'PT-H29GPX');
+});
+
+test('client surfaces typed API errors with numeric Retry-After and server code', async () => {
+  await withMockedFetch(
+    async () => jsonResponse(
+      { error: 'Too many attempts. Please wait before trying again.', code: 'ACCESS_THROTTLED' },
+      { status: 429, headers: { 'Retry-After': '12.2' } }
+    ),
+    async () => {
+      await assert.rejects(resolvePackageAccess('PT-H29GPX', 'Smith'), error => {
+        assert.ok(error instanceof PackagePortalApiError);
+        assert.equal(isPackagePortalApiError(error), true);
+        assert.equal(error.status, 429);
+        assert.equal(error.retryAfter, 13);
+        assert.equal(error.code, 'ACCESS_THROTTLED');
+        assert.match(error.message, /Too many attempts/);
+        return true;
+      });
+    }
+  );
+});
+
+test('successful HTML or malformed JSON is a typed invalid-response failure', async () => {
+  for (const body of ['<html>proxy page</html>', '[]', 'null', '']) {
+    await withMockedFetch(
+      async () => new Response(body, { status: 200, headers: { 'Content-Type': 'text/html' } }),
+      async () => {
+        await assert.rejects(loadPackageData(TOKEN), error => {
+          assert.ok(error instanceof PackagePortalApiError);
+          assert.equal(error.status, 502);
+          assert.equal(error.code, 'INVALID_JSON_RESPONSE');
+          return true;
+        });
+      }
+    );
+  }
+});
+
+test('network errors become typed service failures while AbortError remains abortable', async () => {
+  const networkFailure = new TypeError('network down');
+  await withMockedFetch(async () => { throw networkFailure; }, async () => {
+    await assert.rejects(loadPackageData(TOKEN), error => {
+      assert.ok(error instanceof PackagePortalApiError);
+      assert.equal(error.status, 0);
+      assert.equal(error.cause, networkFailure);
+      return true;
+    });
+  });
+
+  const aborted = new DOMException('cancelled', 'AbortError');
+  await withMockedFetch(async () => { throw aborted; }, async () => {
+    await assert.rejects(loadPackageData(TOKEN), error => error === aborted);
+  });
+});
+
+test('session exchange and logout keep credentials in same-origin headers', async () => {
+  const calls = [];
+  await withMockedFetch(async (url, init) => {
+    calls.push({ url, init });
+    if (init.method === 'DELETE') return new Response('', { status: 200 });
+    return jsonResponse({ sessionEstablished: true });
+  }, async () => {
+    assert.deepEqual(await exchangePackageSession(TOKEN), { sessionEstablished: true });
+    assert.deepEqual(await logoutPackageSession(), {});
+  });
+
+  assert.equal(calls[0].url, '/api/package-session');
+  assert.equal(calls[0].init.method, 'POST');
+  assert.equal(calls[0].init.headers.Authorization, `Bearer ${TOKEN}`);
+  assert.equal(calls[1].url, '/api/package-session');
+  assert.equal(calls[1].init.method, 'DELETE');
+});
+
+test('session-established response header is normalized for phased server rollout', async () => {
+  const result = await withMockedFetch(
+    async () => jsonResponse(
+      { source: 'pt_portal' },
+      { headers: { 'X-Package-Session': 'established' } }
+    ),
+    () => resolvePackageAccess('PT-H29GPX', 'Smith')
+  );
+
+  assert.deepEqual(result, { source: 'pt_portal', sessionEstablished: true });
+});
+
+test('blank session tokens reject locally without issuing a request', async () => {
+  let fetchCalls = 0;
+  await withMockedFetch(async () => { fetchCalls += 1; }, async () => {
+    await assert.rejects(exchangePackageSession('  '), error => {
+      assert.ok(error instanceof PackagePortalApiError);
+      assert.equal(error.status, 400);
+      return true;
+    });
+  });
+  assert.equal(fetchCalls, 0);
+});

--- a/test/package-portal-server.test.js
+++ b/test/package-portal-server.test.js
@@ -1,0 +1,324 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { HttpError } from '../server/http.js';
+import {
+  createPackagePortalClient,
+  isValidPackageToken,
+  normalizeLastName,
+  normalizePackageReference,
+  parseRequestTimeout,
+  requirePackageToken,
+  resolvePtPortalBaseUrl,
+  sanitizeJsonValue,
+  sanitizePackagePayload,
+  sanitizePublicUrl
+} from '../server/package-portal.js';
+import { assertHttpError, jsonResponse } from './helpers.js';
+
+const PORTAL_ENV = Object.freeze({
+  PT_PORTAL_BASE_URL: 'https://portal.example.test/internal/root',
+  PT_PORTAL_REQUEST_TIMEOUT_MS: '5000'
+});
+
+test('package references normalize only the exact six-character contract', () => {
+  for (const [input, expected] of [
+    ['H29GPX', 'PT-H29GPX'],
+    ['PT-H29GPX', 'PT-H29GPX'],
+    [' pt-h29gpx ', 'PT-H29GPX'],
+    ['000000', 'PT-000000']
+  ]) {
+    assert.equal(normalizePackageReference(input), expected);
+  }
+
+  for (const input of [null, 123456, '', 'H29GP', 'H29GPXX', 'PT-PT-H29GPX', 'PT-H29G X', 'PT-H29GP/']) {
+    assert.equal(normalizePackageReference(input), null);
+  }
+});
+
+test('surname normalization trims human names but rejects blank, control, and oversized input', () => {
+  assert.equal(normalizeLastName("  O'Connor-Smith  "), "O'Connor-Smith");
+  assert.equal(normalizeLastName('Çelik'), 'Çelik');
+  assert.equal(normalizeLastName(''), null);
+  assert.equal(normalizeLastName('Smith\nInjected'), null);
+  assert.equal(normalizeLastName('x'.repeat(121)), null);
+  assert.equal(normalizeLastName({}), null);
+});
+
+test('package tokens use a bounded URL-safe opaque format', () => {
+  for (const token of ['abcdEF12', 'opaque_token.with~marks-123', 'x'.repeat(512)]) {
+    assert.equal(isValidPackageToken(token), true);
+    assert.equal(requirePackageToken(` ${token} `), token);
+  }
+
+  for (const token of ['', '1234567', 'x'.repeat(513), 'token/with/slash', 'token with space', 'token?query', null]) {
+    assert.equal(isValidPackageToken(token), false);
+    assert.throws(
+      () => requirePackageToken(token),
+      error => assertHttpError(error, { status: 400, code: 'INVALID_TOKEN' })
+    );
+  }
+});
+
+test('request timeouts default and clamp to one through thirty seconds', () => {
+  assert.equal(parseRequestTimeout(undefined), 10_000);
+  assert.equal(parseRequestTimeout(''), 10_000);
+  assert.equal(parseRequestTimeout('not-a-number'), 10_000);
+  assert.equal(parseRequestTimeout('-1'), 10_000);
+  assert.equal(parseRequestTimeout('1'), 1_000);
+  assert.equal(parseRequestTimeout('1999.9'), 1_999);
+  assert.equal(parseRequestTimeout('5000'), 5_000);
+  assert.equal(parseRequestTimeout('999999'), 30_000);
+});
+
+test('PT-Portal base URLs require HTTPS except for explicit loopback development', () => {
+  assert.equal(resolvePtPortalBaseUrl('https://portal.example.test').href, 'https://portal.example.test/');
+  assert.equal(resolvePtPortalBaseUrl(' https://portal.example.test/base/// ').href, 'https://portal.example.test/base/');
+  assert.equal(resolvePtPortalBaseUrl('http://localhost:3000/api').href, 'http://localhost:3000/api/');
+  assert.equal(resolvePtPortalBaseUrl('http://127.0.0.1:3000').href, 'http://127.0.0.1:3000/');
+
+  for (const value of [
+    undefined,
+    '',
+    'not a URL',
+    'http://portal.example.test',
+    'ftp://portal.example.test',
+    'https://user:pass@portal.example.test',
+    'https://portal.example.test/?query=yes',
+    'https://portal.example.test/#fragment'
+  ]) {
+    assert.throws(
+      () => resolvePtPortalBaseUrl(value),
+      error => assertHttpError(error, { status: 503, code: 'INVALID_BASE_URL' })
+    );
+  }
+});
+
+test('public URL and JSON sanitizers reject unsafe URLs and internal finance data', () => {
+  assert.equal(sanitizePublicUrl('https://files.example.test/doc.pdf'), 'https://files.example.test/doc.pdf');
+  assert.equal(sanitizePublicUrl('http://files.example.test/doc.pdf'), null);
+  assert.equal(sanitizePublicUrl('http://localhost:3000/doc.pdf'), 'http://localhost:3000/doc.pdf');
+  assert.equal(sanitizePublicUrl('javascript:alert(1)'), null);
+  assert.equal(sanitizePublicUrl('https://user:pass@files.example.test/doc.pdf'), null);
+
+  const safe = sanitizeJsonValue({
+    greeting: 'Welcome',
+    nested: { seat: '12A', supplierCost: 75, commission_amount: 20 },
+    internal_notes: 'never public',
+    margin: 12,
+    hiddenChild: { hidden: true, value: 'never public either' }
+  });
+
+  assert.deepEqual(safe, {
+    greeting: 'Welcome',
+    nested: { seat: '12A' },
+    hiddenChild: null
+  });
+});
+
+test('package payload sanitizer accepts released docs with omitted redundant flags and strips private fields', () => {
+  const sanitized = sanitizePackagePayload({
+    package: {
+      id: 'pkg-1',
+      package_reference: 'h29gpx',
+      customer_name: 'Ada Traveller',
+      customer_email: 'ada@example.test',
+      commission: 500,
+      current_public_summary: {
+        welcome: 'Your trip is ready',
+        supplier_cost: 900,
+        nested: { destinationTip: 'Pack light', profitMargin: 40 }
+      }
+    },
+    documents: [
+      {
+        id: 'flight-1',
+        category: 'flight',
+        title: 'Flight ticket',
+        signed_url: 'https://files.example.test/ticket.pdf',
+        metadata: { seat: '12A', supplierCost: 400, internal_notes: 'private' }
+      },
+      {
+        id: 'travel-docs',
+        category: 'Travel Documents',
+        title: 'Internal bundle',
+        signed_url: 'https://files.example.test/internal.pdf'
+      },
+      {
+        id: 'draft-doc',
+        category: 'hotel',
+        title: 'Draft hotel',
+        status: 'draft',
+        signed_url: 'https://files.example.test/draft.pdf'
+      },
+      {
+        id: 'hidden-doc',
+        category: 'visa',
+        title: 'Hidden visa',
+        customer_visible: false,
+        signed_url: 'https://files.example.test/hidden.pdf'
+      }
+    ],
+    releasedInvoice: {
+      invoice_number: 'INV-7',
+      total: 1_200,
+      supplier_cost: 750,
+      internal_notes: 'private invoice note',
+      lines: [{ description: 'Package', sold_amount: 1_200, net_cost: 750 }]
+    },
+    transportVoucher: {
+      voucher_number: 'TV-8',
+      public_notes: 'Meet at arrivals',
+      supplierAllocation: 'private supplier',
+      booked_cost: 80
+    },
+    signedUrlExpiresIn: 100_000
+  });
+
+  assert.equal(sanitized.package.package_reference, 'PT-H29GPX');
+  assert.deepEqual(sanitized.package.current_public_summary, {
+    welcome: 'Your trip is ready',
+    nested: { destinationTip: 'Pack light' }
+  });
+  assert.equal(sanitized.documents.length, 1);
+  assert.equal(sanitized.documents[0].id, 'flight-1');
+  assert.equal(sanitized.documents[0].status, 'released');
+  assert.equal(sanitized.documents[0].customer_visible, true);
+  assert.equal(sanitized.documents[0].metadata, undefined);
+  assert.equal(sanitized.releasedInvoice.supplier_cost, undefined);
+  assert.equal(sanitized.releasedInvoice.internal_notes, undefined);
+  assert.equal(sanitized.releasedInvoice.lines[0].net_cost, undefined);
+  assert.equal(sanitized.transportVoucher.supplierAllocation, undefined);
+  assert.equal(sanitized.transportVoucher.booked_cost, undefined);
+  assert.equal(sanitized.signedUrlExpiresIn, 86_400);
+  assert.doesNotMatch(JSON.stringify(sanitized), /private|supplier cost/i);
+});
+
+test('package payload sanitizer fails closed on malformed required structure', () => {
+  for (const payload of [null, {}, { package: {}, documents: [] }, { package: { package_reference: 'H29GPX' }, documents: [] }]) {
+    assert.throws(
+      () => sanitizePackagePayload(payload),
+      error => assertHttpError(error, { status: 503, code: 'INVALID_UPSTREAM_PAYLOAD' })
+    );
+  }
+});
+
+test('PT access client accepts a valid token and sends only normalized request data', async () => {
+  let captured;
+  const client = createPackagePortalClient({
+    env: PORTAL_ENV,
+    fetchImpl: async (url, init) => {
+      captured = { url, init };
+      return jsonResponse({ token: 'opaque-token-123' }, { status: 200 });
+    }
+  });
+
+  assert.deepEqual(await client.accessPackage('PT-H29GPX', "O'Connor"), {
+    found: true,
+    token: 'opaque-token-123'
+  });
+  assert.equal(captured.url.href, 'https://portal.example.test/internal/root/api/package-portal/access');
+  assert.equal(captured.init.method, 'POST');
+  assert.equal(captured.init.redirect, 'error');
+  assert.deepEqual(JSON.parse(captured.init.body), { reference: 'PT-H29GPX', lastName: "O'Connor" });
+  assert.ok(captured.init.signal instanceof AbortSignal);
+});
+
+test('only a valid JSON upstream 404 is represented as a fallback candidate', async () => {
+  const valid404Client = createPackagePortalClient({
+    env: PORTAL_ENV,
+    fetchImpl: async () => jsonResponse({ error: 'not found' }, { status: 404 })
+  });
+  assert.deepEqual(await valid404Client.accessPackage('PT-H29GPX', 'Smith'), {
+    found: false,
+    token: null
+  });
+
+  const html404Client = createPackagePortalClient({
+    env: PORTAL_ENV,
+    fetchImpl: async () => new Response('<html>not found</html>', { status: 404 })
+  });
+  await assert.rejects(
+    html404Client.accessPackage('PT-H29GPX', 'Smith'),
+    error => assertHttpError(error, { status: 503, code: 'NON_JSON_UPSTREAM_404' })
+  );
+});
+
+test('PT access status mapping preserves customer-safe errors and sanitized Retry-After', async () => {
+  const cases = [
+    [400, 'UPSTREAM_VALIDATION', 400],
+    [410, 'ACCESS_EXPIRED', 410],
+    [429, 'ACCESS_THROTTLED', 429],
+    [500, 'UPSTREAM_ACCESS_ERROR', 503]
+  ];
+
+  for (const [upstreamStatus, code, publicStatus] of cases) {
+    const client = createPackagePortalClient({
+      env: PORTAL_ENV,
+      fetchImpl: async () => jsonResponse(
+        { error: 'upstream detail must not leak' },
+        { status: upstreamStatus, headers: { 'Retry-After': upstreamStatus === 429 ? '9999999' : 'ignored' } }
+      )
+    });
+
+    await assert.rejects(
+      client.accessPackage('PT-H29GPX', 'Smith'),
+      error => {
+        assertHttpError(error, { status: publicStatus, code });
+        if (upstreamStatus === 429) assert.equal(error.retryAfter, null);
+        assert.doesNotMatch(error.message, /upstream detail/);
+        return true;
+      }
+    );
+  }
+
+  const throttledClient = createPackagePortalClient({
+    env: PORTAL_ENV,
+    fetchImpl: async () => jsonResponse({}, { status: 429, headers: { 'Retry-After': '120' } })
+  });
+  await assert.rejects(
+    throttledClient.accessPackage('PT-H29GPX', 'Smith'),
+    error => assertHttpError(error, { status: 429, code: 'ACCESS_THROTTLED', retryAfter: '120' })
+  );
+});
+
+test('malformed successful PT responses fail closed for access and package data', async () => {
+  for (const body of ['<html>gateway page</html>', JSON.stringify({}), JSON.stringify({ token: 'short' })]) {
+    const client = createPackagePortalClient({
+      env: PORTAL_ENV,
+      fetchImpl: async () => new Response(body, { status: 200 })
+    });
+    await assert.rejects(
+      client.accessPackage('PT-H29GPX', 'Smith'),
+      error => assertHttpError(error, { status: 503, code: 'INVALID_UPSTREAM_TOKEN' })
+    );
+  }
+
+  const dataClient = createPackagePortalClient({
+    env: PORTAL_ENV,
+    fetchImpl: async () => new Response('<html>success?</html>', { status: 200 })
+  });
+  await assert.rejects(
+    dataClient.loadPackage('opaque-token-123'),
+    error => assertHttpError(error, { status: 503, code: 'INVALID_UPSTREAM_PAYLOAD' })
+  );
+});
+
+test('transport failures are wrapped without exposing network details', async () => {
+  const client = createPackagePortalClient({
+    env: PORTAL_ENV,
+    fetchImpl: async () => {
+      throw new TypeError('getaddrinfo ENOTFOUND secret.internal');
+    }
+  });
+
+  await assert.rejects(
+    client.accessPackage('PT-H29GPX', 'Smith'),
+    error => {
+      assert.ok(error instanceof HttpError);
+      assertHttpError(error, { status: 503, code: 'UPSTREAM_UNAVAILABLE' });
+      assert.doesNotMatch(error.message, /secret\.internal/);
+      return true;
+    }
+  );
+});

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,83 @@
       "source": "/(.*)",
       "destination": "/index.html"
     }
+  ],
+  "headers": [
+    {
+      "source": "/package-documents/(.*)",
+      "headers": [
+        {
+          "key": "Referrer-Policy",
+          "value": "no-referrer"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "private, no-store"
+        },
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow, noarchive"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
+      ]
+    },
+    {
+      "source": "/documents(.*)",
+      "headers": [
+        {
+          "key": "Referrer-Policy",
+          "value": "no-referrer"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "private, no-store"
+        },
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow, noarchive"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
+      ]
+    },
+    {
+      "source": "/api/package-(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "private, no-store"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "no-referrer"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
+      ]
+    },
+    {
+      "source": "/api/lookup-customer",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "private, no-store"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "no-referrer"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## What changed

- routes package reference/surname access to PT-Portal first, with Firebase fallback only after an authoritative JSON 404
- adds hardened same-origin package access, data, and encrypted HttpOnly session endpoints
- introduces source-specific PT and legacy customer models and keeps legacy Firebase updates working during migration
- adds released-document grouping, safe preview/download behavior, signed-URL refresh, transport voucher, released invoice, checklist, and responsive accessible navigation
- isolates Firebase agent authentication from public customer routes and marks the agent dashboard as legacy-only
- adds environment guidance, deployment/rollback checks, a reproducible lockfile, automated contract tests, and GitHub CI

## Why

PT-Portal is the source of truth for new travel packages, while existing Firebase customer folders must remain available during migration. The bookings portal needs deterministic source routing and a customer-safe read-only interface without exposing operational data, storage credentials, or long-lived tokens.

## Security and behavior

- exact six-character package references; overlong values are rejected rather than truncated
- no Firebase fallback on PT 410, 429, timeout, malformed response, or 5xx
- lazy Firebase Admin initialization and allowlisted legacy responses
- package tokens sent through Authorization or encrypted Secure/HttpOnly cookies, never localStorage
- package responses use private/no-store and token routes use no-referrer/noindex controls
- travel documents, internal metadata, supplier costs, margins, commissions, and hidden release data are filtered out
- direct token logout replaces the route and signed document links refresh without reusing revoked URLs

## Validation

- `npm run check` — 40 cases across four test files passed; Vite production build passed with 103 modules
- `npm ci --dry-run` — passed
- `node --check` — all API/server/test JavaScript passed
- JSON and GitHub workflow configuration validation — passed
- `git diff --check` — passed
- generated browser bundle scan found no server-secret identifiers

## Required deployment gates

- configure Vercel Preview/Production variables and Node 20+
- test a real released PT package, current QR link, known legacy package, mobile layout, and signed-URL refresh
- confirm disabled/revoked PT-owned packages cannot trigger stale Firebase fallback
- confirm customer-specific rate limiting through Vercel egress
- approve Vercel edge-log access, retention, and redaction for the initial token-bearing route

The operational sequence and rollback steps are in `docs/deployment-checklist.md`.
