### PR TITLE
Improve customer package overview

### DIFF
--- a/Bookings portal integration.md
+++ b/Bookings portal integration.md
@@ -512,11 +512,10 @@ Recommended mobile-first sections:
 ```text
 Overview
 Documents
-Transport
 Invoice (only when released)
 ```
 
-Do not render an empty Invoice or Transport tab.
+Show the released transport summary inside Overview rather than as a separate tab. Do not render an empty Invoice tab.
 
 On mobile, use a compact sticky tab row or segmented navigation. Avoid a wide desktop grid compressed into the phone viewport.
 
@@ -595,7 +594,10 @@ For PT-Portal packages, these controls must not write to Firebase.
 Phase 1 recommendation:
 
 - render PT package checklist as read-only status
+- provide a separate personal checklist stored only in the customer's browser session and never sent to PT-Portal or Firebase
 - show customer email as read-only
+- prompt for a missing email or mobile/WhatsApp number and direct the customer to the office to update it securely
+- show the office's 24/7 emergency phone, WhatsApp, and email details on the customer overview
 - direct changes to the agent through WhatsApp
 - do not add customer-write APIs until the exact audit and validation rules are agreed
 

--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -56,6 +56,8 @@ Record pass/fail and the sanitized evidence location for each row.
 | Preview/download | Test PDF, image, HTML voucher, and download-only file behavior. Confirm the supplied filename and new-tab protections. |
 | Signed URL expiry | Leave the portal open until a signed URL expires; the portal refreshes package data and retries only once. |
 | Transport | Only released, customer-safe transport fields appear; no supplier allocation or net cost is visible. View/Print works for the released voucher. |
+| Overview support | Transport appears as an Overview summary, price-like public information is absent, the personal checklist stays browser-session-only, and office emergency contacts are usable. |
+| Contact reminder | A package missing email or mobile/WhatsApp details shows a clear office contact prompt without writing directly to PT-Portal or Firebase. |
 | Invoice | Only the released immutable snapshot appears. Hidden lines, booked cost, margin, commission, draft changes, and internal notes are absent. |
 | Empty states | A package with no released documents shows the approved calm empty state and no empty Transport or Invoice tab. |
 | Logout | Logout clears customer state and any session cookie, replaces a token-bearing URL, and refresh does not reopen the package without valid access. |

--- a/server/package-portal.js
+++ b/server/package-portal.js
@@ -196,6 +196,30 @@ export function sanitizeJsonValue(value, depth = 0) {
   return output;
 }
 
+const PUBLIC_SUMMARY_FINANCIAL_FRAGMENTS = [
+  'price', 'amount', 'balance', 'deposit', 'currency', 'fare', 'quote', 'subtotal', 'grandtotal'
+];
+
+function isPublicSummaryFinancialKey(key) {
+  const normalized = String(key).toLowerCase().replace(/[^a-z0-9]/g, '');
+  return normalized === 'total' || normalized === 'paid' || normalized === 'outstanding' ||
+    PUBLIC_SUMMARY_FINANCIAL_FRAGMENTS.some((fragment) => normalized.includes(fragment));
+}
+
+function removePublicSummaryPricing(value, depth = 0) {
+  if (depth > 8 || value == null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) {
+    return value.map((item) => removePublicSummaryPricing(item, depth + 1));
+  }
+
+  const output = {};
+  for (const [key, childValue] of Object.entries(value)) {
+    if (isPublicSummaryFinancialKey(key)) continue;
+    output[key] = removePublicSummaryPricing(childValue, depth + 1);
+  }
+  return output;
+}
+
 function sanitizeDocument(value) {
   if (!isPlainObject(value)) return null;
   if ('customer_visible' in value && value.customer_visible !== true) return null;
@@ -275,13 +299,21 @@ export function sanitizePackagePayload(payload) {
   }
 
   const publicSummary = isPlainObject(payload.package.current_public_summary)
-    ? sanitizeJsonValue(payload.package.current_public_summary)
+    ? removePublicSummaryPricing(sanitizeJsonValue(payload.package.current_public_summary))
     : {};
   const packageData = {
     id: optionalString(payload.package.id, 200),
     package_reference: packageReference,
     customer_name: customerName,
     customer_email: optionalString(payload.package.customer_email, 500),
+    customer_phone: optionalString(
+      payload.package.customer_phone ?? payload.package.customer_mobile ?? payload.package.customer_contact_number,
+      120
+    ),
+    customer_whatsapp: optionalString(
+      payload.package.customer_whatsapp ?? payload.package.customer_whats_app ?? payload.package.whatsapp_number,
+      120
+    ),
     package_type: optionalString(payload.package.package_type, 200),
     destination: optionalString(payload.package.destination, 500),
     departure_date: optionalString(payload.package.departure_date, 100),

--- a/src/adapters/ptPortalPackageAdapter.js
+++ b/src/adapters/ptPortalPackageAdapter.js
@@ -48,7 +48,8 @@ function normalizePublicSummary(summary) {
 
   const blockedFragments = [
     'internal', 'supplier', 'cost', 'commission', 'margin', 'profit', 'employee',
-    'audit', 'risk', 'shareaccess', 'storage', 'objectkey', 'token'
+    'audit', 'risk', 'shareaccess', 'storage', 'objectkey', 'token', 'price',
+    'amount', 'balance', 'deposit', 'currency', 'fare', 'quote', 'subtotal', 'grandtotal'
   ];
 
   // The object is already designated public by PT-Portal. Keep only scalar values
@@ -57,6 +58,7 @@ function normalizePublicSummary(summary) {
     if (!/^[A-Za-z0-9_-]{1,80}$/.test(key)) return safeSummary;
     if (['__proto__', 'prototype', 'constructor'].includes(key)) return safeSummary;
     const normalizedKey = key.toLowerCase().replace(/[^a-z0-9]/g, '');
+    if (['total', 'paid', 'outstanding'].includes(normalizedKey)) return safeSummary;
     if (blockedFragments.some((fragment) => normalizedKey.includes(fragment))) return safeSummary;
     if (!['string', 'number', 'boolean'].includes(typeof value)) return safeSummary;
     safeSummary[key] = typeof value === 'string' ? cleanText(value, '', 2000) : value;
@@ -126,6 +128,16 @@ export function normalizePtPortalPackage(apiPayload) {
     checklist: normalizeChecklist(rawChecklist, packageData.passport_status || packageData.passportStatus),
     keyInformation: {
       customerEmail: cleanText(packageData.customer_email, '', 254),
+      customerPhone: cleanText(
+        packageData.customer_phone || packageData.customer_mobile || packageData.customer_contact_number,
+        '',
+        120
+      ),
+      customerWhatsApp: cleanText(
+        packageData.customer_whatsapp || packageData.customer_whats_app || packageData.whatsapp_number,
+        '',
+        120
+      ),
       customerName: cleanText(packageData.customer_name, 'Customer', 300)
     },
     signedUrlExpiresIn: Number.isFinite(expiresIn) && expiresIn > 0 ? Math.floor(expiresIn) : null,

--- a/src/components/ClientPortal.jsx
+++ b/src/components/ClientPortal.jsx
@@ -21,7 +21,6 @@ import PackageHeader from './portal/PackageHeader';
 import PackageInvoice from './portal/PackageInvoice';
 import PackageLogin from './portal/PackageLogin';
 import PackageOverview from './portal/PackageOverview';
-import PackageTransportVoucher from './portal/PackageTransportVoucher';
 
 const LegacyClientDashboard = lazy(() => import('./legacy/LegacyClientDashboard'));
 const SIGNED_LINK_REFRESH_LEEWAY_MS = 60_000;
@@ -93,10 +92,9 @@ function PtPortalDashboard({ customer, isRefreshing, refreshMessage, onLogout, o
       { id: 'overview', label: 'Overview' },
       { id: 'documents', label: 'Documents' }
     ];
-    if (customer.transportVoucher) availableTabs.push({ id: 'transport', label: 'Transport' });
     if (customer.releasedInvoice) availableTabs.push({ id: 'invoice', label: 'Invoice' });
     return availableTabs;
-  }, [customer.releasedInvoice, customer.transportVoucher]);
+  }, [customer.releasedInvoice]);
 
   useEffect(() => {
     if (!tabs.some((tab) => tab.id === activeTab)) setActiveTab('overview');
@@ -232,7 +230,7 @@ function PtPortalDashboard({ customer, isRefreshing, refreshMessage, onLogout, o
           tabIndex={0}
           className="focus:outline-none"
         >
-          {activeTab === 'overview' && <PackageOverview customer={customer} />}
+          {activeTab === 'overview' && <PackageOverview customer={customer} onOpenDocuments={() => setActiveTab('documents')} />}
           {activeTab === 'documents' && (
             <>
               <div className="mb-4 flex justify-end">
@@ -253,7 +251,6 @@ function PtPortalDashboard({ customer, isRefreshing, refreshMessage, onLogout, o
               />
             </>
           )}
-          {activeTab === 'transport' && <PackageTransportVoucher voucher={customer.transportVoucher} />}
           {activeTab === 'invoice' && <PackageInvoice invoice={customer.releasedInvoice} />}
         </div>
       </div>

--- a/src/components/legacy/LegacyClientDashboard.jsx
+++ b/src/components/legacy/LegacyClientDashboard.jsx
@@ -13,6 +13,8 @@ import {
   UserIcon,
   XIcon
 } from '../Icons';
+import PackageSupportContacts from '../portal/PackageSupportContacts';
+import PersonalTravelChecklist from '../portal/PersonalTravelChecklist';
 
 function formatExpiryDate(customer) {
   const dateToUse = customer.accessExpiresAt || customer.createdAt;
@@ -274,6 +276,11 @@ export default function LegacyClientDashboard({ customer, onLogout, onCustomerUp
         ) : (
           <div className="py-12 text-center"><p className="text-gray-500">No documents have been uploaded for you yet.</p></div>
         )}
+
+        <div className="mt-8 space-y-4">
+          <PackageSupportContacts customerEmail={localEmail} customerPhone={localSim} />
+          <PersonalTravelChecklist reference={customer.referenceNumber} />
+        </div>
 
         <footer className="mt-8 border-t border-gray-200 pt-4 dark:border-gray-700">
           <div className="flex items-center justify-center rounded-lg bg-slate-50 p-3 text-sm text-gray-500 dark:bg-slate-700">

--- a/src/components/portal/PackageOverview.jsx
+++ b/src/components/portal/PackageOverview.jsx
@@ -1,5 +1,18 @@
 import React from 'react';
 import { formatPortalDate } from '../../utils/packagePortal';
+import PackageSupportContacts from './PackageSupportContacts';
+import PackageTransportVoucher from './PackageTransportVoucher';
+import PersonalTravelChecklist from './PersonalTravelChecklist';
+
+const FINANCIAL_PUBLIC_INFO_FRAGMENTS = [
+  'price', 'amount', 'balance', 'deposit', 'currency', 'fare', 'quote', 'subtotal', 'grandtotal'
+];
+
+function isFinancialPublicInfoKey(key) {
+  const normalized = String(key).toLowerCase().replace(/[^a-z0-9]/g, '');
+  return normalized === 'total' || normalized === 'paid' || normalized === 'outstanding' ||
+    FINANCIAL_PUBLIC_INFO_FRAGMENTS.some((fragment) => normalized.includes(fragment));
+}
 
 function formatSummaryLabel(key) {
   return String(key)
@@ -13,11 +26,27 @@ function formatSummaryValue(value) {
   return String(value);
 }
 
-export default function PackageOverview({ customer }) {
+function getExpiryNotice(value, now = Date.now()) {
+  if (!value) return null;
+  const expiresAt = new Date(value).getTime();
+  if (!Number.isFinite(expiresAt)) return null;
+  const daysRemaining = Math.ceil((expiresAt - now) / 86_400_000);
+  if (daysRemaining < 0) return 'Your package access has expired. Contact our office for help.';
+  if (daysRemaining === 0) return 'Your package access expires today. Download any documents you need.';
+  if (daysRemaining <= 30) return `Your package access expires in ${daysRemaining} day${daysRemaining === 1 ? '' : 's'}. Download any documents you need.`;
+  return null;
+}
+
+export default function PackageOverview({ customer, onOpenDocuments }) {
   const publicSummary = customer?.publicSummary && typeof customer.publicSummary === 'object'
-    ? Object.entries(customer.publicSummary).filter(([, value]) => ['string', 'number', 'boolean'].includes(typeof value))
+    ? Object.entries(customer.publicSummary).filter(([key, value]) =>
+      !isFinancialPublicInfoKey(key) && ['string', 'number', 'boolean'].includes(typeof value)
+    )
     : [];
   const checklist = Array.isArray(customer?.checklist) ? customer.checklist : [];
+  const documentCount = Array.isArray(customer?.documents) ? customer.documents.length : 0;
+  const expiryNotice = getExpiryNotice(customer?.accessExpiresAt);
+  const keyInformation = customer?.keyInformation || {};
 
   return (
     <section className="mb-6 space-y-4" aria-labelledby="package-overview-heading">
@@ -37,10 +66,33 @@ export default function PackageOverview({ customer }) {
           <h3 className="mb-2 text-lg font-bold">Package Status</h3>
           <dl className="space-y-1 text-sm text-gray-700 dark:text-gray-200">
             <div><dt className="inline font-semibold">Status: </dt><dd className="inline capitalize">{customer?.statusLabel || 'Open'}</dd></div>
-            <div><dt className="inline font-semibold">Customer email: </dt><dd className="inline break-all">{customer?.keyInformation?.customerEmail || 'Not supplied'}</dd></div>
+            <div><dt className="inline font-semibold">Released documents: </dt><dd className="inline">{documentCount}</dd></div>
           </dl>
+          {typeof onOpenDocuments === 'function' && (
+            <button
+              type="button"
+              onClick={onOpenDocuments}
+              className="mt-3 min-h-10 rounded-lg bg-red-800 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+            >
+              {documentCount > 0 ? 'View released documents' : 'Check document releases'}
+            </button>
+          )}
         </div>
       </div>
+
+      {expiryNotice && (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm font-semibold text-amber-950 dark:border-amber-700 dark:bg-amber-950/30 dark:text-amber-100" role="note">
+          {expiryNotice}
+        </div>
+      )}
+
+      <PackageSupportContacts
+        customerEmail={keyInformation.customerEmail}
+        customerPhone={keyInformation.customerPhone}
+        customerWhatsApp={keyInformation.customerWhatsApp}
+      />
+
+      {customer?.transportVoucher && <PackageTransportVoucher voucher={customer.transportVoucher} />}
 
       {publicSummary.length > 0 && (
         <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-600 dark:bg-gray-800">
@@ -58,7 +110,7 @@ export default function PackageOverview({ customer }) {
 
       {checklist.length > 0 && (
         <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-700">
-          <h3 className="mb-3 font-bold text-gray-800 dark:text-gray-100">Travel checklist status</h3>
+          <h3 className="mb-3 font-bold text-gray-800 dark:text-gray-100">Booking checklist status</h3>
           <ul className="space-y-2" aria-label="Read-only travel checklist">
             {checklist.map((item, index) => (
               <li key={item.id || `checklist-${index}`} className="flex items-start gap-3 rounded-md bg-white p-3 dark:bg-gray-800">
@@ -79,6 +131,8 @@ export default function PackageOverview({ customer }) {
           <p className="mt-3 text-xs text-gray-500">This information is read-only. Contact your agent if anything needs changing.</p>
         </div>
       )}
+
+      <PersonalTravelChecklist reference={customer?.reference} />
     </section>
   );
 }

--- a/src/components/portal/PackageSupportContacts.jsx
+++ b/src/components/portal/PackageSupportContacts.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { CONTACT_UPDATE_WHATSAPP_URL, OFFICE_SUPPORT } from '../../utils/customerSupport';
+
+function cleanContact(value, maxLength = 254) {
+  if (!['string', 'number'].includes(typeof value)) return '';
+  return String(value).trim().slice(0, maxLength);
+}
+
+export default function PackageSupportContacts({ customerEmail, customerPhone, customerWhatsApp }) {
+  const email = cleanContact(customerEmail);
+  const phone = cleanContact(customerPhone, 120);
+  const whatsApp = cleanContact(customerWhatsApp, 120);
+  const hasEmail = Boolean(email);
+  const hasMobileContact = Boolean(phone || whatsApp);
+  const contactDetailsComplete = hasEmail && hasMobileContact;
+
+  return (
+    <section className="grid grid-cols-1 gap-4 md:grid-cols-2" aria-label="Customer and emergency contact details">
+      <div className={`rounded-lg border p-4 ${contactDetailsComplete ? 'border-slate-200 bg-slate-50 dark:border-slate-600 dark:bg-slate-700' : 'border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-950/30'}`}>
+        <h3 className="font-bold text-gray-800 dark:text-gray-100">Your contact details</h3>
+        <dl className="mt-2 space-y-1 text-sm text-gray-700 dark:text-gray-200">
+          <div><dt className="inline font-semibold">Email: </dt><dd className="inline break-all">{email || 'Not provided'}</dd></div>
+          <div><dt className="inline font-semibold">Mobile: </dt><dd className="inline break-words">{phone || whatsApp || 'Not provided'}</dd></div>
+        </dl>
+        {!contactDetailsComplete && (
+          <div className="mt-3" role="note">
+            <p className="text-sm font-semibold text-amber-950 dark:text-amber-100">
+              Please add {!hasEmail && !hasMobileContact ? 'an email address and mobile/WhatsApp number' : !hasEmail ? 'an email address' : 'a mobile/WhatsApp number'} to your booking.
+            </p>
+            <p className="mt-1 text-xs text-amber-900 dark:text-amber-200">
+              Message or call our office so an agent can update your booking securely.
+            </p>
+            <a
+              href={CONTACT_UPDATE_WHATSAPP_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              referrerPolicy="no-referrer"
+              className="mt-3 inline-flex min-h-10 items-center justify-center rounded-lg bg-emerald-700 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2"
+            >
+              Update details by WhatsApp
+            </a>
+          </div>
+        )}
+      </div>
+
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-900 dark:bg-red-950/30">
+        <h3 className="font-bold text-red-950 dark:text-red-100">Piyam Travel emergency contact</h3>
+        <p className="mt-1 text-xs text-red-900 dark:text-red-200">Available 24/7 while you are travelling.</p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <a href={`tel:${OFFICE_SUPPORT.phoneDial}`} className="inline-flex min-h-10 items-center rounded-lg bg-red-800 px-3 py-2 text-sm font-semibold text-white hover:bg-red-700">
+            Call {OFFICE_SUPPORT.phoneDisplay}
+          </a>
+          <a
+            href={OFFICE_SUPPORT.whatsAppUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            referrerPolicy="no-referrer"
+            className="inline-flex min-h-10 items-center rounded-lg border border-red-800 px-3 py-2 text-sm font-semibold text-red-900 hover:bg-white dark:text-red-100"
+          >
+            WhatsApp office
+          </a>
+          <a href={`mailto:${OFFICE_SUPPORT.email}`} className="inline-flex min-h-10 items-center rounded-lg border border-red-800 px-3 py-2 text-sm font-semibold text-red-900 hover:bg-white dark:text-red-100">
+            {OFFICE_SUPPORT.email}
+          </a>
+        </div>
+        <p className="mt-3 text-xs text-red-900 dark:text-red-200">
+          If there is immediate danger or a medical emergency, contact the local emergency services first.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/portal/PackageTransportVoucher.jsx
+++ b/src/components/portal/PackageTransportVoucher.jsx
@@ -51,7 +51,7 @@ export default function PackageTransportVoucher({ voucher }) {
       <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <h2 id="transport-voucher-heading" className="text-xl font-semibold text-gray-700 dark:text-gray-300">
-            Transport Voucher
+            Transport Summary
           </h2>
           <div className="text-sm text-gray-500">
             {safeVoucher.voucherNumber && <span>Voucher {safeVoucher.voucherNumber}</span>}

--- a/src/components/portal/PersonalTravelChecklist.jsx
+++ b/src/components/portal/PersonalTravelChecklist.jsx
@@ -1,0 +1,167 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+export const PERSONAL_CHECKLIST_ITEMS = Object.freeze([
+  { id: 'passport', label: 'Passport and required travel documents packed' },
+  { id: 'downloads', label: 'Tickets and vouchers downloaded for offline access' },
+  { id: 'medication', label: 'Medication and essential items packed' },
+  { id: 'connectivity', label: 'Roaming, local SIM or E-Sim arrangements checked' },
+  { id: 'transport', label: 'Arrival and transport details reviewed' },
+  { id: 'emergency', label: 'Piyam Travel emergency number saved' }
+]);
+
+export function personalChecklistStorageKey(reference) {
+  const safeReference = String(reference || 'package').replace(/[^A-Za-z0-9-]/g, '').slice(0, 80);
+  return `piyam-personal-checklist:${safeReference || 'package'}`;
+}
+
+function readStoredChecklist(storageKey) {
+  if (typeof window === 'undefined') return { completed: {}, customItems: [] };
+
+  try {
+    const parsed = JSON.parse(window.sessionStorage.getItem(storageKey) || '{}');
+    const completed = parsed?.completed && typeof parsed.completed === 'object' && !Array.isArray(parsed.completed)
+      ? Object.fromEntries(Object.entries(parsed.completed).filter(([, value]) => typeof value === 'boolean'))
+      : {};
+    const customItems = Array.isArray(parsed?.customItems)
+      ? parsed.customItems
+        .slice(0, 20)
+        .filter((item) => item && typeof item.id === 'string' && typeof item.label === 'string')
+        .map((item) => ({ id: item.id.slice(0, 100), label: item.label.trim().slice(0, 120) }))
+        .filter((item) => item.id && item.label)
+      : [];
+    return { completed, customItems };
+  } catch (_error) {
+    return { completed: {}, customItems: [] };
+  }
+}
+
+export default function PersonalTravelChecklist({ reference }) {
+  const storageKey = useMemo(() => personalChecklistStorageKey(reference), [reference]);
+  const [state, setState] = useState(() => ({ storageKey, ...readStoredChecklist(storageKey) }));
+  const [newItem, setNewItem] = useState('');
+
+  useEffect(() => {
+    setState({ storageKey, ...readStoredChecklist(storageKey) });
+  }, [storageKey]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || state.storageKey !== storageKey) return;
+    try {
+      window.sessionStorage.setItem(storageKey, JSON.stringify({
+        completed: state.completed,
+        customItems: state.customItems
+      }));
+    } catch (_error) {
+      // Checklist remains usable in memory when browser storage is unavailable.
+    }
+  }, [state, storageKey]);
+
+  const allItems = [
+    ...PERSONAL_CHECKLIST_ITEMS,
+    ...state.customItems.map((item) => ({ ...item, custom: true }))
+  ];
+  const completedCount = allItems.filter((item) => state.completed[item.id] === true).length;
+
+  const toggleItem = (itemId) => {
+    setState((current) => ({
+      ...current,
+      completed: {
+        ...current.completed,
+        [itemId]: current.completed[itemId] !== true
+      }
+    }));
+  };
+
+  const addItem = (event) => {
+    event.preventDefault();
+    const label = newItem.trim().slice(0, 120);
+    if (!label || state.customItems.length >= 20) return;
+    const id = `custom-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    setState((current) => ({ ...current, customItems: [...current.customItems, { id, label }] }));
+    setNewItem('');
+  };
+
+  const removeItem = (itemId) => {
+    setState((current) => {
+      const completed = { ...current.completed };
+      delete completed[itemId];
+      return {
+        ...current,
+        completed,
+        customItems: current.customItems.filter((item) => item.id !== itemId)
+      };
+    });
+  };
+
+  const resetChecklist = () => setState((current) => ({ ...current, completed: {}, customItems: [] }));
+
+  return (
+    <section className="rounded-lg border border-emerald-200 bg-emerald-50 p-4 dark:border-emerald-800 dark:bg-emerald-950/30" aria-labelledby="personal-checklist-heading">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h3 id="personal-checklist-heading" className="font-bold text-gray-800 dark:text-gray-100">My personal checklist</h3>
+          <p className="mt-1 text-xs text-gray-600 dark:text-gray-300">
+            Private to this browser tab. It is not sent to Piyam Travel or added to your booking.
+          </p>
+        </div>
+        <p className="shrink-0 text-sm font-semibold text-emerald-800 dark:text-emerald-200" aria-live="polite">
+          {completedCount} of {allItems.length} complete
+        </p>
+      </div>
+
+      <ul className="mt-4 space-y-2">
+        {allItems.map((item) => (
+          <li key={item.id} className="flex items-start gap-2 rounded-md bg-white p-3 dark:bg-gray-800">
+            <label className="flex min-w-0 flex-1 cursor-pointer items-start gap-3">
+              <input
+                type="checkbox"
+                checked={state.completed[item.id] === true}
+                onChange={() => toggleItem(item.id)}
+                className="mt-0.5 h-5 w-5 shrink-0 rounded border-gray-300 text-emerald-700 focus:ring-emerald-600"
+              />
+              <span className={`break-words text-sm ${state.completed[item.id] ? 'text-gray-500 line-through dark:text-gray-400' : 'text-gray-800 dark:text-gray-100'}`}>
+                {item.label}
+              </span>
+            </label>
+            {item.custom && (
+              <button
+                type="button"
+                onClick={() => removeItem(item.id)}
+                className="shrink-0 rounded px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 dark:text-red-300 dark:hover:bg-gray-700"
+                aria-label={`Remove ${item.label}`}
+              >
+                Remove
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      <form onSubmit={addItem} className="mt-3 flex flex-col gap-2 sm:flex-row">
+        <label htmlFor="personal-checklist-item" className="sr-only">Add a personal checklist item</label>
+        <input
+          id="personal-checklist-item"
+          type="text"
+          value={newItem}
+          onChange={(event) => setNewItem(event.target.value)}
+          maxLength={120}
+          placeholder="Add your own reminder"
+          className="min-h-10 min-w-0 flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-900"
+        />
+        <button
+          type="submit"
+          disabled={!newItem.trim() || state.customItems.length >= 20}
+          className="min-h-10 rounded-lg bg-emerald-700 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Add reminder
+        </button>
+      </form>
+
+      {(completedCount > 0 || state.customItems.length > 0) && (
+        <button type="button" onClick={resetChecklist} className="mt-3 text-xs font-semibold text-gray-600 underline hover:text-gray-900 dark:text-gray-300">
+          Reset my checklist
+        </button>
+      )}
+    </section>
+  );
+}

--- a/src/types/packagePortal.js
+++ b/src/types/packagePortal.js
@@ -99,7 +99,7 @@
  * @property {PortalTransportVoucher|null} transportVoucher
  * @property {PortalInvoice|null} releasedInvoice
  * @property {PortalChecklistItem[]} checklist
- * @property {{customerEmail: string, customerName: string}} keyInformation
+ * @property {{customerEmail: string, customerPhone: string, customerWhatsApp: string, customerName: string}} keyInformation
  * @property {number|null} signedUrlExpiresIn
  * @property {string} loadedAt ISO time when URLs were loaded.
  *

--- a/src/utils/customerSupport.js
+++ b/src/utils/customerSupport.js
@@ -1,0 +1,9 @@
+export const OFFICE_SUPPORT = Object.freeze({
+  email: 'info@piyamtravel.com',
+  phoneDisplay: '+44 7400 828212',
+  phoneDial: '+447400828212',
+  whatsAppUrl: 'https://wa.me/447400828212'
+});
+
+export const CONTACT_UPDATE_WHATSAPP_URL =
+  `${OFFICE_SUPPORT.whatsAppUrl}?text=${encodeURIComponent('Hello, I would like to update my contact details for my travel package.')}`;

--- a/test/legacy-and-adapters.test.js
+++ b/test/legacy-and-adapters.test.js
@@ -75,6 +75,15 @@ test('PT adapter accepts omitted release flags and rejects explicit hidden, draf
       package_reference: 'PT-H29GPX',
       customer_name: 'Ada Smith',
       customer_email: 'ada@example.test',
+      customer_phone: '+44 7000 000000',
+      customer_whatsapp: '+44 7111 111111',
+      current_public_summary: {
+        welcome: 'Your package is ready',
+        package_price: 1_500,
+        balance_due: 500,
+        total: 1_500,
+        currency: 'GBP'
+      },
       destination: 'Istanbul'
     },
     documents: [
@@ -87,6 +96,9 @@ test('PT adapter accepts omitted release flags and rejects explicit hidden, draf
 
   assert.equal(normalized.source, 'pt_portal');
   assert.equal(normalized.reference, 'PT-H29GPX');
+  assert.deepEqual(normalized.publicSummary, { welcome: 'Your package is ready' });
+  assert.equal(normalized.keyInformation.customerPhone, '+44 7000 000000');
+  assert.equal(normalized.keyInformation.customerWhatsApp, '+44 7111 111111');
   assert.equal(normalized.documents.length, 1);
   assert.deepEqual(normalized.documents[0], {
     id: 'visible',

--- a/test/package-portal-server.test.js
+++ b/test/package-portal-server.test.js
@@ -123,11 +123,16 @@ test('package payload sanitizer accepts released docs with omitted redundant fla
       package_reference: 'h29gpx',
       customer_name: 'Ada Traveller',
       customer_email: 'ada@example.test',
+      customer_phone: '+44 7000 000000',
+      customer_whatsapp: '+44 7111 111111',
       commission: 500,
       current_public_summary: {
         welcome: 'Your trip is ready',
+        package_price: 1_200,
+        balance_due: 400,
+        total: 1_200,
         supplier_cost: 900,
-        nested: { destinationTip: 'Pack light', profitMargin: 40 }
+        nested: { destinationTip: 'Pack light', roomPrice: 600, profitMargin: 40 }
       }
     },
     documents: [
@@ -180,6 +185,8 @@ test('package payload sanitizer accepts released docs with omitted redundant fla
     welcome: 'Your trip is ready',
     nested: { destinationTip: 'Pack light' }
   });
+  assert.equal(sanitized.package.customer_phone, '+44 7000 000000');
+  assert.equal(sanitized.package.customer_whatsapp, '+44 7111 111111');
   assert.equal(sanitized.documents.length, 1);
   assert.equal(sanitized.documents[0].id, 'flight-1');
   assert.equal(sanitized.documents[0].status, 'released');


### PR DESCRIPTION
## What changed

- remove price and other financial fields from customer-facing Public Information at both the server and adapter boundaries
- move the transport summary into Overview and remove the separate Transport tab
- add a personal travel checklist that stays in the customer's current browser tab and is never written to PT-Portal or Firebase
- show the customer's known contact details and prompt them to contact the office when email or mobile/WhatsApp details are missing
- add the Piyam Travel 24/7 emergency phone, WhatsApp, and email details
- add a released-document count, a quick Documents action, and an access-expiry warning
- apply the support contacts and private checklist to both PT and legacy customer packages

## Security and privacy

- financial Public Information keys are filtered before they reach the browser and filtered again before rendering
- the checklist uses session storage only
- the contact-update WhatsApp message contains no package reference, token, or customer data
- customer package data remains read-only; office staff make any requested booking updates through the existing managed process

## Validation

- `npm run check`
- 4 Node test suites passed
- Vite production build passed (106 modules)
- `git diff --cached --check`
