### PR TITLE
Polish customer portal experience

### DIFF
--- a/Bookings portal integration.md
+++ b/Bookings portal integration.md
@@ -512,10 +512,11 @@ Recommended mobile-first sections:
 ```text
 Overview
 Documents
-Invoice (only when released)
+My Checklist
+Invoice
 ```
 
-Show the released transport summary inside Overview rather than as a separate tab. Do not render an empty Invoice tab.
+Show the released transport summary inside Overview rather than as a separate tab. Keep the personal browser-session checklist in its own tab. The Invoice tab is always visible during the beta but renders only an explicit **Coming soon** state; it must not display invoice or pricing data until the invoice experience is approved for release.
 
 On mobile, use a compact sticky tab row or segmented navigation. Avoid a wide desktop grid compressed into the phone viewport.
 
@@ -562,7 +563,9 @@ When a released transport document is available, include a clear **View / Print 
 
 ### 10.6 Released Invoice
 
-Show only the immutable customer snapshot returned as `releasedInvoice`:
+Current beta behaviour: show a **Coming soon** page and an office contact route for customers who need an invoice copy. Do not render any `releasedInvoice` values yet.
+
+When the invoice experience is approved, show only the immutable customer snapshot returned as `releasedInvoice`:
 
 - invoice number and version
 - customer-visible line descriptions
@@ -600,6 +603,7 @@ Phase 1 recommendation:
 - show the office's 24/7 emergency phone, WhatsApp, and email details on the customer overview
 - direct changes to the agent through WhatsApp
 - do not add customer-write APIs until the exact audit and validation rules are agreed
+- show a site-wide beta/work-in-progress notice, a consistent light/dark theme, and the customer-facing Rathobixz Inc. development attribution
 
 Future customer-write endpoints should live in PT-Portal and record audit events. They should not update Supabase directly from the bookings portal browser.
 
@@ -827,11 +831,9 @@ bookings.piyamtravel.com by reference/surname and by QR token.
 
 ### Invoice
 
-- draft invoice is hidden
-- released invoice appears
-- amended but unreleased invoice does not replace the released snapshot
-- only customer-visible lines appear
-- booked cost, margin, and commission are absent
+- Invoice tab is always present and clearly marked **Coming soon**
+- no draft, released, amended, line-item, price, balance, cost, margin, or commission data appears
+- the office contact action does not include customer or package data in its URL
 
 ### Mobile
 
@@ -839,7 +841,7 @@ bookings.piyamtravel.com by reference/surname and by QR token.
 - tabs remain usable with one hand
 - document actions do not overlap filenames
 - preview can be closed without browser back navigation
-- price/invoice tables collapse into readable rows
+- Overview, Documents, My Checklist, and Invoice remain keyboard and touch accessible
 - no IMS install prompt appears
 
 ### Security

--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -56,10 +56,13 @@ Record pass/fail and the sanitized evidence location for each row.
 | Preview/download | Test PDF, image, HTML voucher, and download-only file behavior. Confirm the supplied filename and new-tab protections. |
 | Signed URL expiry | Leave the portal open until a signed URL expires; the portal refreshes package data and retries only once. |
 | Transport | Only released, customer-safe transport fields appear; no supplier allocation or net cost is visible. View/Print works for the released voucher. |
-| Overview support | Transport appears as an Overview summary, price-like public information is absent, the personal checklist stays browser-session-only, and office emergency contacts are usable. |
+| Overview support | Transport appears as an Overview summary, price-like public information is absent, and office emergency contacts are usable. |
+| Personal checklist | The checklist has its own tab, stays browser-session-only, and remains isolated when the customer switches packages. |
 | Contact reminder | A package missing email or mobile/WhatsApp details shows a clear office contact prompt without writing directly to PT-Portal or Firebase. |
-| Invoice | Only the released immutable snapshot appears. Hidden lines, booked cost, margin, commission, draft changes, and internal notes are absent. |
-| Empty states | A package with no released documents shows the approved calm empty state and no empty Transport or Invoice tab. |
+| Invoice | The always-visible Invoice tab shows only the approved Coming soon state. No invoice, line-item, price, balance, cost, margin, commission, draft, or internal-note data appears. |
+| Beta shell | The work-in-progress banner and Rathobixz Inc. footer appear on login, package, and controlled-error states; Support and Privacy email links work. |
+| Dark mode | Login, all four tabs, alerts, cards, forms, checklist, preview, banner, and footer remain readable with visible focus states in dark mode. |
+| Empty states | A package with no released documents shows the approved calm empty state and no empty Transport section. |
 | Logout | Logout clears customer state and any session cookie, replaces a token-bearing URL, and refresh does not reopen the package without valid access. |
 | Error semantics | Validate <code>400</code>, <code>404</code>, <code>410</code>, <code>429</code>, timeout, malformed upstream response, and <code>5xx</code>. Every API response is JSON and outages are not described as invalid details. |
 | Cache/referrer | Package-data responses are <code>private, no-store</code>. Token pages and previews do not send token-bearing referrers. |

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,19 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 const ClientPortal = lazy(() => import('./components/ClientPortal'));
 const AgentPortal = lazy(() => import('./components/AgentPortal'));
 
+function getInitialTheme() {
+  try {
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme === 'light' || storedTheme === 'dark') return storedTheme;
+  } catch (_error) {
+    // Fall through to the visitor's operating-system preference.
+  }
+
+  return typeof window !== 'undefined' && window.matchMedia?.('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
+}
+
 function RouteLoading() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-100 dark:bg-gray-900">
@@ -13,13 +26,7 @@ function RouteLoading() {
 }
 
 export default function App() {
-  const [theme, setTheme] = useState(() => {
-    try {
-      return localStorage.getItem('theme') || 'light';
-    } catch (_error) {
-      return 'light';
-    }
-  });
+  const [theme, setTheme] = useState(getInitialTheme);
 
   const toggleTheme = () => {
     const newTheme = theme === 'light' ? 'dark' : 'light';
@@ -32,31 +39,31 @@ export default function App() {
   };
 
   useEffect(() => {
-    if (theme === 'dark') {
-      document.documentElement.classList.add('dark');
-    } else {
-      document.documentElement.classList.remove('dark');
-    }
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    document.documentElement.style.colorScheme = theme;
   }, [theme]);
 
   return (
-    <div className="relative">
-        <button
-            onClick={toggleTheme}
-            className="fixed bottom-4 right-4 bg-gray-200 dark:bg-gray-700 p-2 rounded-full z-50 shadow-lg"
-            aria-label="Toggle theme"
-        >
-            {theme === 'light' ? '🌙' : '☀️'}
-        </button>
-        <Suspense fallback={<RouteLoading />}>
-          <Routes>
-              <Route path="/" element={<ClientPortal />} />
-              <Route path="/documents" element={<ClientPortal />} />
-              <Route path="/package-documents/:token" element={<ClientPortal />} />
-              <Route path="/agent" element={<AgentPortal />} />
-              <Route path="*" element={<Navigate to="/" replace />} />
-          </Routes>
-        </Suspense>
+    <div className="relative min-h-screen">
+      <button
+        type="button"
+        onClick={toggleTheme}
+        className="fixed bottom-4 right-4 z-50 inline-flex min-h-11 items-center gap-2 rounded-full border border-slate-300 bg-white/95 px-3 py-2 text-sm font-semibold text-slate-800 shadow-lg backdrop-blur transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:border-slate-600 dark:bg-slate-800/95 dark:text-slate-100 dark:hover:bg-slate-700 dark:focus:ring-offset-slate-950"
+        aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+        aria-pressed={theme === 'dark'}
+      >
+        <span aria-hidden="true">{theme === 'light' ? '🌙' : '☀️'}</span>
+        <span className="hidden sm:inline">{theme === 'light' ? 'Dark mode' : 'Light mode'}</span>
+      </button>
+      <Suspense fallback={<RouteLoading />}>
+        <Routes>
+          <Route path="/" element={<ClientPortal />} />
+          <Route path="/documents" element={<ClientPortal />} />
+          <Route path="/package-documents/:token" element={<ClientPortal />} />
+          <Route path="/agent" element={<AgentPortal />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </Suspense>
     </div>
   );
 }

--- a/src/components/ClientPortal.jsx
+++ b/src/components/ClientPortal.jsx
@@ -21,6 +21,9 @@ import PackageHeader from './portal/PackageHeader';
 import PackageInvoice from './portal/PackageInvoice';
 import PackageLogin from './portal/PackageLogin';
 import PackageOverview from './portal/PackageOverview';
+import PersonalTravelChecklist from './portal/PersonalTravelChecklist';
+import PortalFooter from './portal/PortalFooter';
+import PortalWorkInProgressBanner from './portal/PortalWorkInProgressBanner';
 
 const LegacyClientDashboard = lazy(() => import('./legacy/LegacyClientDashboard'));
 const SIGNED_LINK_REFRESH_LEEWAY_MS = 60_000;
@@ -87,14 +90,14 @@ function PtPortalDashboard({ customer, isRefreshing, refreshMessage, onLogout, o
   const [previewDocument, setPreviewDocument] = useState(null);
   const [actionMessage, setActionMessage] = useState('');
 
-  const tabs = useMemo(() => {
-    const availableTabs = [
+  const tabs = useMemo(() => (
+    [
       { id: 'overview', label: 'Overview' },
-      { id: 'documents', label: 'Documents' }
-    ];
-    if (customer.releasedInvoice) availableTabs.push({ id: 'invoice', label: 'Invoice' });
-    return availableTabs;
-  }, [customer.releasedInvoice]);
+      { id: 'documents', label: 'Documents' },
+      { id: 'checklist', label: 'My Checklist' },
+      { id: 'invoice', label: 'Invoice' }
+    ]
+  ), []);
 
   useEffect(() => {
     if (!tabs.some((tab) => tab.id === activeTab)) setActiveTab('overview');
@@ -186,12 +189,12 @@ function PtPortalDashboard({ customer, isRefreshing, refreshMessage, onLogout, o
 
   return (
     <>
-      <div className="w-full rounded-2xl bg-white p-4 shadow-xl dark:bg-gray-800 sm:p-6 md:p-8">
+      <div className="w-full rounded-2xl border border-transparent bg-white p-4 shadow-xl dark:border-slate-800 dark:bg-slate-900 dark:shadow-black/30 sm:p-6 md:p-8">
         <PackageHeader customer={customer} onLogout={onLogout} />
 
         {(isRefreshing || refreshMessage || actionMessage) && (
           <div
-            className={`mb-4 rounded-lg border p-3 text-sm ${refreshMessage || actionMessage ? 'border-amber-300 bg-amber-50 text-amber-950' : 'border-blue-200 bg-blue-50 text-blue-900'}`}
+            className={`mb-4 rounded-lg border p-3 text-sm ${refreshMessage || actionMessage ? 'border-amber-300 bg-amber-50 text-amber-950 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100' : 'border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100'}`}
             role={refreshMessage || actionMessage ? 'alert' : 'status'}
             aria-live="polite"
           >
@@ -199,7 +202,7 @@ function PtPortalDashboard({ customer, isRefreshing, refreshMessage, onLogout, o
           </div>
         )}
 
-        <div className="sticky top-0 z-10 -mx-4 mb-6 border-y border-gray-200 bg-white/95 px-4 py-2 backdrop-blur dark:border-gray-700 dark:bg-gray-800/95 sm:mx-0 sm:rounded-lg sm:border sm:px-2">
+        <div className="sticky top-0 z-10 -mx-4 mb-6 border-y border-gray-200 bg-white/95 px-4 py-2 backdrop-blur dark:border-slate-700 dark:bg-slate-900/95 sm:mx-0 sm:rounded-lg sm:border sm:px-2">
           <div className="flex gap-2 overflow-x-auto" role="tablist" aria-label="Package sections" aria-orientation="horizontal">
             {tabs.map((tab, index) => {
               const selected = tab.id === activeTab;
@@ -214,7 +217,7 @@ function PtPortalDashboard({ customer, isRefreshing, refreshMessage, onLogout, o
                   tabIndex={selected ? 0 : -1}
                   onClick={() => setActiveTab(tab.id)}
                   onKeyDown={(event) => handleTabKeyDown(event, index)}
-                  className={`min-h-10 shrink-0 rounded-full px-4 py-2 text-sm font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-red-500 ${selected ? 'bg-red-800 text-white' : 'border border-red-800 text-red-800 hover:bg-red-50 dark:text-red-200 dark:hover:bg-gray-700'}`}
+                  className={`min-h-10 shrink-0 rounded-full px-4 py-2 text-sm font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-red-500 dark:focus:ring-offset-slate-900 ${selected ? 'bg-red-800 text-white shadow-sm dark:bg-red-700' : 'border border-red-800 text-red-800 hover:bg-red-50 dark:border-red-500 dark:text-red-200 dark:hover:bg-slate-800'}`}
                 >
                   {tab.label}
                 </button>
@@ -251,7 +254,8 @@ function PtPortalDashboard({ customer, isRefreshing, refreshMessage, onLogout, o
               />
             </>
           )}
-          {activeTab === 'invoice' && <PackageInvoice invoice={customer.releasedInvoice} />}
+          {activeTab === 'checklist' && <PersonalTravelChecklist reference={customer.reference} />}
+          {activeTab === 'invoice' && <PackageInvoice />}
         </div>
       </div>
 
@@ -479,8 +483,12 @@ export default function ClientPortal() {
 
   const isDashboard = Boolean(portalPackage);
   return (
-    <main className={`min-h-screen bg-slate-50 p-3 dark:bg-slate-900 sm:p-4 ${isDashboard ? 'flex items-start justify-center py-5 sm:py-8' : 'flex items-center justify-center'}`}>
-      <div className="w-full max-w-5xl">{content}</div>
-    </main>
+    <div className="flex min-h-screen flex-col bg-slate-50 dark:bg-slate-950">
+      <PortalWorkInProgressBanner />
+      <main className={`flex flex-1 p-3 sm:p-4 ${isDashboard ? 'items-start justify-center py-5 sm:py-8' : 'items-center justify-center py-8'}`}>
+        <div className="w-full max-w-5xl">{content}</div>
+      </main>
+      <PortalFooter />
+    </div>
   );
 }

--- a/src/components/legacy/LegacyClientDashboard.jsx
+++ b/src/components/legacy/LegacyClientDashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { doc, serverTimestamp, updateDoc } from 'firebase/firestore';
 import { db } from '../../firebase';
 import { fileCategories } from '../../data';
@@ -14,7 +14,15 @@ import {
   XIcon
 } from '../Icons';
 import PackageSupportContacts from '../portal/PackageSupportContacts';
+import PackageInvoice from '../portal/PackageInvoice';
 import PersonalTravelChecklist from '../portal/PersonalTravelChecklist';
+
+const LEGACY_TABS = Object.freeze([
+  { id: 'overview', label: 'Overview' },
+  { id: 'documents', label: 'Documents' },
+  { id: 'checklist', label: 'My Checklist' },
+  { id: 'invoice', label: 'Invoice' }
+]);
 
 function formatExpiryDate(customer) {
   const dateToUse = customer.accessExpiresAt || customer.createdAt;
@@ -48,6 +56,7 @@ function getLegacyPreviewKind(file) {
 }
 
 export default function LegacyClientDashboard({ customer, onLogout, onCustomerUpdate }) {
+  const [activeTab, setActiveTab] = useState('overview');
   const [previewFile, setPreviewFile] = useState(null);
   const [isChecklistVisible, setIsChecklistVisible] = useState(true);
   const [localSim, setLocalSim] = useState(customer.keyInformation?.customerSim || '');
@@ -68,6 +77,20 @@ export default function LegacyClientDashboard({ customer, onLogout, onCustomerUp
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [previewFile]);
+
+  const handleTabKeyDown = useCallback((event, currentIndex) => {
+    let nextIndex = currentIndex;
+    if (event.key === 'ArrowRight') nextIndex = (currentIndex + 1) % LEGACY_TABS.length;
+    else if (event.key === 'ArrowLeft') nextIndex = (currentIndex - 1 + LEGACY_TABS.length) % LEGACY_TABS.length;
+    else if (event.key === 'Home') nextIndex = 0;
+    else if (event.key === 'End') nextIndex = LEGACY_TABS.length - 1;
+    else return;
+
+    event.preventDefault();
+    const nextTab = LEGACY_TABS[nextIndex];
+    setActiveTab(nextTab.id);
+    window.requestAnimationFrame(() => document.getElementById(`legacy-package-tab-${nextTab.id}`)?.focus());
+  }, []);
 
   const handleSaveContactInfo = async () => {
     const newKeyInfo = {
@@ -116,7 +139,7 @@ export default function LegacyClientDashboard({ customer, onLogout, onCustomerUp
 
   return (
     <>
-      <div className="w-full rounded-2xl bg-white p-6 shadow-xl dark:bg-gray-800 md:p-8">
+      <div className="w-full rounded-2xl border border-transparent bg-white p-6 shadow-xl dark:border-slate-800 dark:bg-slate-900 dark:shadow-black/30 md:p-8">
         <header className="mb-8 flex flex-col items-start justify-between gap-4 border-b border-gray-200 pb-6 dark:border-gray-700 md:flex-row">
           <div>
             <p className="font-mono text-sm text-gray-500">Reference: {customer.referenceNumber}</p>
@@ -143,7 +166,40 @@ export default function LegacyClientDashboard({ customer, onLogout, onCustomerUp
           </div>
         </header>
 
-        <section className="mb-8 rounded-lg bg-red-800 p-4 text-white">
+        <div className="sticky top-0 z-10 -mx-6 mb-6 border-y border-gray-200 bg-white/95 px-4 py-2 backdrop-blur dark:border-slate-700 dark:bg-slate-900/95 sm:mx-0 sm:rounded-lg sm:border sm:px-2">
+          <div className="flex gap-2 overflow-x-auto" role="tablist" aria-label="Package sections" aria-orientation="horizontal">
+            {LEGACY_TABS.map((tab, index) => {
+              const selected = tab.id === activeTab;
+              return (
+                <button
+                  key={tab.id}
+                  type="button"
+                  id={`legacy-package-tab-${tab.id}`}
+                  role="tab"
+                  aria-selected={selected}
+                  aria-controls={`legacy-package-panel-${tab.id}`}
+                  tabIndex={selected ? 0 : -1}
+                  onClick={() => setActiveTab(tab.id)}
+                  onKeyDown={(event) => handleTabKeyDown(event, index)}
+                  className={`min-h-10 shrink-0 rounded-full px-4 py-2 text-sm font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-red-500 dark:focus:ring-offset-slate-900 ${selected ? 'bg-red-800 text-white shadow-sm dark:bg-red-700' : 'border border-red-800 text-red-800 hover:bg-red-50 dark:border-red-500 dark:text-red-200 dark:hover:bg-slate-800'}`}
+                >
+                  {tab.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div
+          id={`legacy-package-panel-${activeTab}`}
+          role="tabpanel"
+          aria-labelledby={`legacy-package-tab-${activeTab}`}
+          tabIndex={0}
+          className="focus:outline-none"
+        >
+        {activeTab === 'overview' && (
+          <div className="space-y-6">
+        <section className="rounded-lg bg-red-800 p-4 text-white dark:bg-red-950 dark:ring-1 dark:ring-red-800">
           <h2 className="mb-4 text-lg font-bold">Key Information</h2>
           <div className="grid grid-cols-1 gap-x-8 gap-y-4 text-sm md:grid-cols-2">
             <div className="flex items-start gap-3">
@@ -172,7 +228,7 @@ export default function LegacyClientDashboard({ customer, onLogout, onCustomerUp
                   value={localSim}
                   onChange={(event) => setLocalSim(event.target.value)}
                   placeholder="Enter your local number"
-                  className="mt-1 w-full rounded border border-white/30 bg-white/20 p-1"
+                  className="mt-1 w-full rounded border border-white/40 bg-white/20 p-2 text-white placeholder:text-red-100 focus:border-white focus:ring-white"
                 />
               </div>
             </div>
@@ -186,7 +242,7 @@ export default function LegacyClientDashboard({ customer, onLogout, onCustomerUp
                   value={localEmail}
                   onChange={(event) => setLocalEmail(event.target.value)}
                   placeholder="Enter your email"
-                  className={`mt-1 w-full rounded border border-white/30 bg-white/20 p-1 ${!isEmailEditable ? 'cursor-not-allowed bg-black/20' : ''}`}
+                  className={`mt-1 w-full rounded border border-white/40 bg-white/20 p-2 text-white placeholder:text-red-100 focus:border-white focus:ring-white ${!isEmailEditable ? 'cursor-not-allowed bg-black/20' : ''}`}
                   disabled={!isEmailEditable}
                 />
               </div>
@@ -200,9 +256,14 @@ export default function LegacyClientDashboard({ customer, onLogout, onCustomerUp
             Save My Info
           </button>
         </section>
+            <PackageSupportContacts customerEmail={localEmail} customerPhone={localSim} />
+          </div>
+        )}
 
-        {checklist.length > 0 && (
-          <section className="mb-8">
+        {activeTab === 'checklist' && (
+          <div className="space-y-6">
+          {checklist.length > 0 && (
+          <section>
             <div className="mb-4 flex items-center justify-between">
               <h2 className="text-xl font-semibold text-gray-700 dark:text-gray-300">Your Pre-Travel Checklist</h2>
               <button
@@ -214,7 +275,7 @@ export default function LegacyClientDashboard({ customer, onLogout, onCustomerUp
               </button>
             </div>
             {isChecklistVisible && (
-              <div className="space-y-3 rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-700">
+              <div className="space-y-3 rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800">
                 {checklist.map((item) => (
                   <label key={item.id} className="flex cursor-pointer items-center rounded-md p-2 transition-colors hover:bg-slate-100 dark:hover:bg-slate-600">
                     <input
@@ -231,19 +292,24 @@ export default function LegacyClientDashboard({ customer, onLogout, onCustomerUp
               </div>
             )}
           </section>
+          )}
+          <PersonalTravelChecklist reference={customer.referenceNumber} />
+          </div>
         )}
 
+        {activeTab === 'documents' && (
+          <section>
         <h2 className="mb-4 text-xl font-semibold text-gray-700 dark:text-gray-300">Your Documents</h2>
         {visibleCategories.length > 0 ? (
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
             {visibleCategories.map((category) => (
-              <section key={category.name} className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-700">
+              <section key={category.name} className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800">
                 <h3 className="mb-4 text-lg font-bold">{category.icon} {category.name}</h3>
                 <div className="space-y-3">
                   {customer.documents
                     .filter((document) => document.category === category.name)
                     .map((file) => (
-                      <article key={file.id} className="rounded-lg border bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+                      <article key={file.id} className="rounded-lg border bg-white p-3 dark:border-slate-700 dark:bg-slate-900">
                         <div className="mb-3 flex min-w-0 items-center">
                           <FileIcon className="mr-3 h-5 w-5 flex-shrink-0 text-gray-500" />
                           <span className="truncate font-medium text-gray-800 dark:text-gray-200">{file.name}</span>
@@ -276,14 +342,14 @@ export default function LegacyClientDashboard({ customer, onLogout, onCustomerUp
         ) : (
           <div className="py-12 text-center"><p className="text-gray-500">No documents have been uploaded for you yet.</p></div>
         )}
+          </section>
+        )}
 
-        <div className="mt-8 space-y-4">
-          <PackageSupportContacts customerEmail={localEmail} customerPhone={localSim} />
-          <PersonalTravelChecklist reference={customer.referenceNumber} />
+        {activeTab === 'invoice' && <PackageInvoice />}
         </div>
 
         <footer className="mt-8 border-t border-gray-200 pt-4 dark:border-gray-700">
-          <div className="flex items-center justify-center rounded-lg bg-slate-50 p-3 text-sm text-gray-500 dark:bg-slate-700">
+          <div className="flex items-center justify-center rounded-lg bg-slate-50 p-3 text-sm text-gray-500 dark:bg-slate-800 dark:text-slate-300">
             <InfoIcon className="mr-3 h-5 w-5 flex-shrink-0" />
             For your security, access to this portal will expire on {formatExpiryDate(customer)}. Please download any documents you wish to keep.
           </div>
@@ -301,10 +367,10 @@ export default function LegacyClientDashboard({ customer, onLogout, onCustomerUp
             if (event.target === event.currentTarget) setPreviewFile(null);
           }}
         >
-          <div className="flex h-full max-h-[90vh] w-full max-w-4xl flex-col rounded-lg bg-white shadow-2xl">
-            <div className="flex flex-shrink-0 items-center justify-between border-b p-4">
-              <h2 id="legacy-preview-title" className="truncate text-lg font-bold">{previewFile.name}</h2>
-              <button type="button" onClick={() => setPreviewFile(null)} className="text-gray-400 hover:text-gray-800" aria-label="Close document preview">
+          <div className="flex h-full max-h-[90vh] w-full max-w-4xl flex-col rounded-lg bg-white shadow-2xl dark:bg-slate-900">
+            <div className="flex flex-shrink-0 items-center justify-between border-b p-4 dark:border-slate-700">
+              <h2 id="legacy-preview-title" className="truncate text-lg font-bold text-slate-900 dark:text-white">{previewFile.name}</h2>
+              <button type="button" onClick={() => setPreviewFile(null)} className="text-gray-400 hover:text-gray-800 dark:hover:text-white" aria-label="Close document preview">
                 <XIcon className="h-6 w-6" />
               </button>
             </div>

--- a/src/components/portal/PackageDocuments.jsx
+++ b/src/components/portal/PackageDocuments.jsx
@@ -69,11 +69,11 @@ export default function PackageDocuments({ documents, onPreview, onDownload, onV
       <h2 id="package-documents-heading" className="mb-4 text-xl font-semibold text-gray-700 dark:text-gray-300">
         Your Documents
       </h2>
-      {actionError && <p className="mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-700" role="alert">{actionError}</p>}
+      {actionError && <p className="mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-700 dark:bg-red-950 dark:text-red-200" role="alert">{actionError}</p>}
       {visibleCategories.length > 0 ? (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 lg:gap-6">
           {visibleCategories.map(categoryKey => (
-            <section key={categoryKey} className="min-w-0 rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-slate-600 dark:bg-slate-700 sm:p-4">
+            <section key={categoryKey} className="min-w-0 rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-800 sm:p-4">
               <h3 className="mb-4 font-bold text-gray-800 dark:text-gray-100">
                 <span aria-hidden="true">{CATEGORY_ICONS[categoryKey] || '📄'} </span>
                 {CATEGORY_LABELS[categoryKey] || 'Other'}
@@ -87,7 +87,7 @@ export default function PackageDocuments({ documents, onPreview, onDownload, onV
                   const htmlActionKey = `html:${document.id}`;
 
                   return (
-                    <article key={document.id} className="min-w-0 rounded-lg border bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+                    <article key={document.id} className="min-w-0 rounded-lg border bg-white p-3 dark:border-slate-700 dark:bg-slate-900">
                       <div className="mb-2 flex min-w-0 items-start gap-3">
                         <FileIcon className="mt-0.5 h-5 w-5 flex-shrink-0 text-gray-500" />
                         <div className="min-w-0">

--- a/src/components/portal/PackageHeader.jsx
+++ b/src/components/portal/PackageHeader.jsx
@@ -11,7 +11,7 @@ export default function PackageHeader({ customer, onLogout }) {
   return (
     <div className="flex flex-col md:flex-row justify-between items-start mb-8 gap-4 border-b border-gray-200 dark:border-gray-700 pb-6">
       <div className="flex min-w-0 items-start gap-3 sm:items-center sm:gap-4">
-        <div className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-full border border-red-100 bg-red-50">
+        <div className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-full border border-red-100 bg-red-50 dark:border-red-900 dark:bg-white">
           <PiyamTravelLogo />
         </div>
         <div className="min-w-0">

--- a/src/components/portal/PackageInvoice.jsx
+++ b/src/components/portal/PackageInvoice.jsx
@@ -1,98 +1,23 @@
 import React from 'react';
-import { normalizeReleasedInvoice } from '../../adapters/portalReleaseAdapters';
-import { formatMoney, formatPortalDate, formatQuantity } from '../../utils/packagePortal';
+import { OFFICE_SUPPORT } from '../../utils/customerSupport';
 
-function AmountRow({ label, value, currency, strong = false }) {
-  const formatted = formatMoney(value, currency);
-  if (!formatted) return null;
-
+export default function PackageInvoice() {
   return (
-    <div className={`flex items-baseline justify-between gap-4 ${strong ? 'border-t border-gray-300 pt-3 text-base font-bold dark:border-gray-600' : ''}`}>
-      <dt>{label}</dt>
-      <dd className="text-right tabular-nums">{formatted}</dd>
-    </div>
-  );
-}
-
-/** `invoice` may be raw or normalized; only explicitly whitelisted fields render. */
-export default function PackageInvoice({ invoice }) {
-  const safeInvoice = normalizeReleasedInvoice(invoice);
-  if (!safeInvoice) return null;
-
-  return (
-    <section className="mb-6" aria-labelledby="released-invoice-heading">
-      <div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <h2 id="released-invoice-heading" className="text-xl font-semibold text-gray-700 dark:text-gray-300">
-            Released Invoice
-          </h2>
-          {safeInvoice.invoiceNumber && (
-            <p className="text-sm text-gray-500">Invoice {safeInvoice.invoiceNumber}</p>
-          )}
-        </div>
-        <div className="text-sm text-gray-500 sm:text-right">
-          {safeInvoice.version && <p>Version {safeInvoice.version}</p>}
-          {safeInvoice.releasedAt && <p>Released {formatPortalDate(safeInvoice.releasedAt)}</p>}
-        </div>
-      </div>
-
-      <div className="space-y-4">
-        {safeInvoice.lines.length > 0 && (
-          <div className="space-y-3" aria-label="Invoice items">
-            {safeInvoice.lines.map(line => (
-              <article key={line.id} className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-600 dark:bg-gray-800">
-                <h3 className="break-words font-semibold text-gray-800 dark:text-gray-100">{line.description}</h3>
-                <dl className="mt-2 grid grid-cols-1 gap-2 text-sm text-gray-600 dark:text-gray-300 sm:grid-cols-3">
-                  {line.quantity !== null && (
-                    <div>
-                      <dt className="text-xs uppercase tracking-wide text-gray-500">Quantity</dt>
-                      <dd>{formatQuantity(line.quantity)}</dd>
-                    </div>
-                  )}
-                  {line.soldAmount !== null && (
-                    <div>
-                      <dt className="text-xs uppercase tracking-wide text-gray-500">Sold amount</dt>
-                      <dd className="tabular-nums">{formatMoney(line.soldAmount, safeInvoice.currency)}</dd>
-                    </div>
-                  )}
-                  {line.lineTotal !== null && (
-                    <div className="sm:text-right">
-                      <dt className="text-xs uppercase tracking-wide text-gray-500">Line total</dt>
-                      <dd className="font-semibold tabular-nums">{formatMoney(line.lineTotal, safeInvoice.currency)}</dd>
-                    </div>
-                  )}
-                </dl>
-              </article>
-            ))}
-          </div>
-        )}
-
-        <div className="grid gap-4 md:grid-cols-2">
-          <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-gray-700 dark:border-slate-600 dark:bg-slate-700 dark:text-gray-200">
-            <dl className="space-y-3">
-              <AmountRow label="Subtotal" value={safeInvoice.subtotal} currency={safeInvoice.currency} />
-              <AmountRow label="Discount" value={safeInvoice.discount} currency={safeInvoice.currency} />
-              <AmountRow label="Total" value={safeInvoice.total} currency={safeInvoice.currency} strong />
-              <AmountRow label="Amount paid" value={safeInvoice.amountPaid} currency={safeInvoice.currency} />
-              <AmountRow label="Balance due" value={safeInvoice.balanceDue} currency={safeInvoice.currency} strong />
-            </dl>
-            {safeInvoice.dueDate && (
-              <p className="mt-4 border-t border-gray-300 pt-3 dark:border-gray-600">
-                <span className="font-semibold">Due date:</span> {formatPortalDate(safeInvoice.dueDate)}
-              </p>
-            )}
-          </div>
-
-          {safeInvoice.customerTerms && (
-            <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-700">
-              <h3 className="font-semibold text-gray-800 dark:text-gray-100">Customer terms</h3>
-              <p className="mt-2 whitespace-pre-line break-words text-sm text-gray-600 dark:text-gray-300">
-                {safeInvoice.customerTerms}
-              </p>
-            </div>
-          )}
-        </div>
-      </div>
+    <section className="mb-6 rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-5 py-12 text-center dark:border-slate-700 dark:bg-slate-900" aria-labelledby="invoice-coming-soon-heading">
+      <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-red-100 text-2xl dark:bg-red-950" aria-hidden="true">🧾</div>
+      <p className="mx-auto mt-5 inline-flex rounded-full bg-amber-100 px-3 py-1 text-xs font-bold uppercase tracking-wider text-amber-900 dark:bg-amber-950 dark:text-amber-200">
+        Coming soon
+      </p>
+      <h2 id="invoice-coming-soon-heading" className="mt-3 text-2xl font-bold text-slate-900 dark:text-white">Invoices are being prepared for this portal</h2>
+      <p className="mx-auto mt-3 max-w-xl text-sm leading-6 text-slate-600 dark:text-slate-300">
+        You will be able to view customer invoices here in a future update. No invoice or pricing information is currently displayed on this page.
+      </p>
+      <p className="mt-4 text-sm text-slate-600 dark:text-slate-300">
+        Need a copy now? Email{' '}
+        <a className="font-semibold text-red-800 underline hover:text-red-600 dark:text-red-300 dark:hover:text-red-200" href={`mailto:${OFFICE_SUPPORT.email}?subject=${encodeURIComponent('Invoice copy request')}`}>
+          {OFFICE_SUPPORT.email}
+        </a>.
+      </p>
     </section>
   );
 }

--- a/src/components/portal/PackageLogin.jsx
+++ b/src/components/portal/PackageLogin.jsx
@@ -150,11 +150,11 @@ export default function PackageLogin({ onAuthenticated, onLogin }) {
   const describedBy = [errorId, retryId].filter(Boolean).join(' ') || undefined;
 
   return (
-    <div className="overflow-hidden rounded-2xl border-t-4 border-red-800 bg-white shadow-xl dark:bg-gray-800">
+    <div className="overflow-hidden rounded-2xl border border-slate-200 border-t-4 border-t-red-800 bg-white shadow-xl dark:border-slate-800 dark:border-t-red-700 dark:bg-slate-900 dark:shadow-black/30">
       <div className="p-5 sm:p-8">
         <div className="mb-6 flex justify-center"><PiyamTravelLogo /></div>
         <h1 className="mb-2 text-center text-2xl font-bold text-gray-800 dark:text-gray-200">Client Document Portal</h1>
-        <p className="mb-8 text-center text-gray-500">Access your travel documents securely.</p>
+        <p className="mb-8 text-center text-gray-500 dark:text-slate-400">Access your travel documents securely.</p>
 
         <form className="space-y-6" onSubmit={handleSubmit} aria-busy={isSubmitting} noValidate>
           <div>
@@ -206,7 +206,7 @@ export default function PackageLogin({ onAuthenticated, onLogin }) {
           </div>
 
           <div className="min-h-5 text-center" aria-live="assertive">
-            {error && <p id={errorId} className="text-sm text-red-600" role="alert">{error}</p>}
+            {error && <p id={errorId} className="text-sm text-red-600 dark:text-red-300" role="alert">{error}</p>}
             {retrySeconds > 0 && (
               <p id={retryId} className="mt-1 text-sm text-gray-600 dark:text-gray-300">
                 You can try again in {retrySeconds} second{retrySeconds === 1 ? '' : 's'}.

--- a/src/components/portal/PackageOverview.jsx
+++ b/src/components/portal/PackageOverview.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { formatPortalDate } from '../../utils/packagePortal';
 import PackageSupportContacts from './PackageSupportContacts';
 import PackageTransportVoucher from './PackageTransportVoucher';
-import PersonalTravelChecklist from './PersonalTravelChecklist';
 
 const FINANCIAL_PUBLIC_INFO_FRAGMENTS = [
   'price', 'amount', 'balance', 'deposit', 'currency', 'fare', 'quote', 'subtotal', 'grandtotal'
@@ -52,7 +51,7 @@ export default function PackageOverview({ customer, onOpenDocuments }) {
     <section className="mb-6 space-y-4" aria-labelledby="package-overview-heading">
       <h2 id="package-overview-heading" className="sr-only">Package overview</h2>
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-        <div className="rounded-lg bg-red-800 p-4 text-white">
+        <div className="rounded-lg bg-red-800 p-4 text-white dark:bg-red-950 dark:ring-1 dark:ring-red-800">
           <h3 className="mb-2 text-lg font-bold">Package Summary</h3>
           <dl className="space-y-1 text-sm">
             <div><dt className="inline font-semibold">Destination: </dt><dd className="inline break-words">{customer?.destination || 'Not supplied'}</dd></div>
@@ -62,7 +61,7 @@ export default function PackageOverview({ customer, onOpenDocuments }) {
           </dl>
         </div>
 
-        <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-700">
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800">
           <h3 className="mb-2 text-lg font-bold">Package Status</h3>
           <dl className="space-y-1 text-sm text-gray-700 dark:text-gray-200">
             <div><dt className="inline font-semibold">Status: </dt><dd className="inline capitalize">{customer?.statusLabel || 'Open'}</dd></div>
@@ -95,7 +94,7 @@ export default function PackageOverview({ customer, onOpenDocuments }) {
       {customer?.transportVoucher && <PackageTransportVoucher voucher={customer.transportVoucher} />}
 
       {publicSummary.length > 0 && (
-        <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-600 dark:bg-gray-800">
+        <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900">
           <h3 className="mb-3 font-bold text-gray-800 dark:text-gray-100">Public information</h3>
           <dl className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
             {publicSummary.map(([key, value]) => (
@@ -109,11 +108,11 @@ export default function PackageOverview({ customer, onOpenDocuments }) {
       )}
 
       {checklist.length > 0 && (
-        <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-700">
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800">
           <h3 className="mb-3 font-bold text-gray-800 dark:text-gray-100">Booking checklist status</h3>
           <ul className="space-y-2" aria-label="Read-only travel checklist">
             {checklist.map((item, index) => (
-              <li key={item.id || `checklist-${index}`} className="flex items-start gap-3 rounded-md bg-white p-3 dark:bg-gray-800">
+              <li key={item.id || `checklist-${index}`} className="flex items-start gap-3 rounded-md bg-white p-3 dark:bg-slate-900">
                 <span
                   className={`mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-xs font-bold ${item.completed ? 'bg-green-100 text-green-800' : 'bg-gray-200 text-gray-600 dark:bg-gray-600 dark:text-gray-100'}`}
                   aria-hidden="true"
@@ -132,7 +131,6 @@ export default function PackageOverview({ customer, onOpenDocuments }) {
         </div>
       )}
 
-      <PersonalTravelChecklist reference={customer?.reference} />
     </section>
   );
 }

--- a/src/components/portal/PackageSupportContacts.jsx
+++ b/src/components/portal/PackageSupportContacts.jsx
@@ -16,7 +16,7 @@ export default function PackageSupportContacts({ customerEmail, customerPhone, c
 
   return (
     <section className="grid grid-cols-1 gap-4 md:grid-cols-2" aria-label="Customer and emergency contact details">
-      <div className={`rounded-lg border p-4 ${contactDetailsComplete ? 'border-slate-200 bg-slate-50 dark:border-slate-600 dark:bg-slate-700' : 'border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-950/30'}`}>
+      <div className={`rounded-lg border p-4 ${contactDetailsComplete ? 'border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-800' : 'border-amber-300 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/60'}`}>
         <h3 className="font-bold text-gray-800 dark:text-gray-100">Your contact details</h3>
         <dl className="mt-2 space-y-1 text-sm text-gray-700 dark:text-gray-200">
           <div><dt className="inline font-semibold">Email: </dt><dd className="inline break-all">{email || 'Not provided'}</dd></div>
@@ -43,7 +43,7 @@ export default function PackageSupportContacts({ customerEmail, customerPhone, c
         )}
       </div>
 
-      <div className="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-900 dark:bg-red-950/30">
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-900 dark:bg-red-950/60">
         <h3 className="font-bold text-red-950 dark:text-red-100">Piyam Travel emergency contact</h3>
         <p className="mt-1 text-xs text-red-900 dark:text-red-200">Available 24/7 while you are travelling.</p>
         <div className="mt-3 flex flex-wrap gap-2">
@@ -55,11 +55,11 @@ export default function PackageSupportContacts({ customerEmail, customerPhone, c
             target="_blank"
             rel="noopener noreferrer"
             referrerPolicy="no-referrer"
-            className="inline-flex min-h-10 items-center rounded-lg border border-red-800 px-3 py-2 text-sm font-semibold text-red-900 hover:bg-white dark:text-red-100"
+            className="inline-flex min-h-10 items-center rounded-lg border border-red-800 px-3 py-2 text-sm font-semibold text-red-900 hover:bg-white dark:border-red-600 dark:text-red-100 dark:hover:bg-red-900"
           >
             WhatsApp office
           </a>
-          <a href={`mailto:${OFFICE_SUPPORT.email}`} className="inline-flex min-h-10 items-center rounded-lg border border-red-800 px-3 py-2 text-sm font-semibold text-red-900 hover:bg-white dark:text-red-100">
+          <a href={`mailto:${OFFICE_SUPPORT.email}`} className="inline-flex min-h-10 items-center rounded-lg border border-red-800 px-3 py-2 text-sm font-semibold text-red-900 hover:bg-white dark:border-red-600 dark:text-red-100 dark:hover:bg-red-900">
             {OFFICE_SUPPORT.email}
           </a>
         </div>

--- a/src/components/portal/PersonalTravelChecklist.jsx
+++ b/src/components/portal/PersonalTravelChecklist.jsx
@@ -96,7 +96,7 @@ export default function PersonalTravelChecklist({ reference }) {
   const resetChecklist = () => setState((current) => ({ ...current, completed: {}, customItems: [] }));
 
   return (
-    <section className="rounded-lg border border-emerald-200 bg-emerald-50 p-4 dark:border-emerald-800 dark:bg-emerald-950/30" aria-labelledby="personal-checklist-heading">
+    <section className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 dark:border-emerald-800 dark:bg-emerald-950/60 sm:p-5" aria-labelledby="personal-checklist-heading">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <h3 id="personal-checklist-heading" className="font-bold text-gray-800 dark:text-gray-100">My personal checklist</h3>
@@ -111,7 +111,7 @@ export default function PersonalTravelChecklist({ reference }) {
 
       <ul className="mt-4 space-y-2">
         {allItems.map((item) => (
-          <li key={item.id} className="flex items-start gap-2 rounded-md bg-white p-3 dark:bg-gray-800">
+          <li key={item.id} className="flex items-start gap-2 rounded-md border border-transparent bg-white p-3 dark:border-emerald-900 dark:bg-slate-900">
             <label className="flex min-w-0 flex-1 cursor-pointer items-start gap-3">
               <input
                 type="checkbox"
@@ -127,7 +127,7 @@ export default function PersonalTravelChecklist({ reference }) {
               <button
                 type="button"
                 onClick={() => removeItem(item.id)}
-                className="shrink-0 rounded px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 dark:text-red-300 dark:hover:bg-gray-700"
+                className="shrink-0 rounded px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 dark:text-red-300 dark:hover:bg-slate-800"
                 aria-label={`Remove ${item.label}`}
               >
                 Remove
@@ -146,7 +146,7 @@ export default function PersonalTravelChecklist({ reference }) {
           onChange={(event) => setNewItem(event.target.value)}
           maxLength={120}
           placeholder="Add your own reminder"
-          className="min-h-10 min-w-0 flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-900"
+          className="min-h-10 min-w-0 flex-1 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:border-emerald-600 focus:ring-emerald-600 dark:border-slate-600 dark:bg-slate-950"
         />
         <button
           type="submit"
@@ -158,7 +158,7 @@ export default function PersonalTravelChecklist({ reference }) {
       </form>
 
       {(completedCount > 0 || state.customItems.length > 0) && (
-        <button type="button" onClick={resetChecklist} className="mt-3 text-xs font-semibold text-gray-600 underline hover:text-gray-900 dark:text-gray-300">
+        <button type="button" onClick={resetChecklist} className="mt-3 text-xs font-semibold text-gray-600 underline hover:text-gray-900 dark:text-slate-300 dark:hover:text-white">
           Reset my checklist
         </button>
       )}

--- a/src/components/portal/PortalFooter.jsx
+++ b/src/components/portal/PortalFooter.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { OFFICE_SUPPORT } from '../../utils/customerSupport';
+
+export default function PortalFooter() {
+  const year = new Date().getFullYear();
+  const privacyEmail = `mailto:${OFFICE_SUPPORT.email}?subject=${encodeURIComponent('Bookings portal privacy enquiry')}`;
+
+  return (
+    <footer className="border-t border-slate-200 bg-white px-4 py-6 dark:border-slate-800 dark:bg-slate-950">
+      <div className="mx-auto flex max-w-5xl flex-col items-center justify-between gap-4 text-center text-xs text-slate-500 dark:text-slate-400 sm:flex-row sm:text-left">
+        <div>
+          <p className="font-semibold text-slate-700 dark:text-slate-200">Developed by Rathobixz Inc.</p>
+          <p>© {year} Piyam Travel. All rights reserved.</p>
+        </div>
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <span>Customer portal beta</span>
+          <span aria-hidden="true">•</span>
+          <a className="font-medium hover:text-slate-800 hover:underline dark:hover:text-slate-100" href={`mailto:${OFFICE_SUPPORT.email}`}>Support</a>
+          <span aria-hidden="true">•</span>
+          <a className="font-medium hover:text-slate-800 hover:underline dark:hover:text-slate-100" href={privacyEmail}>Privacy</a>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/portal/PortalWorkInProgressBanner.jsx
+++ b/src/components/portal/PortalWorkInProgressBanner.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function PortalWorkInProgressBanner() {
+  return (
+    <aside className="border-b border-amber-300 bg-amber-50 px-4 py-3 text-amber-950 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100" role="status">
+      <div className="mx-auto flex max-w-5xl items-start gap-3 text-sm">
+        <span className="mt-0.5" aria-hidden="true">🚧</span>
+        <p>
+          <span className="font-bold">Portal improvements are in progress.</span>{' '}
+          Some sections are still being developed while we continue improving your experience.
+        </p>
+      </div>
+    </aside>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -3,34 +3,40 @@
 @tailwind utilities;
 
 @layer base {
+  html {
+    color-scheme: light;
+  }
+  html.dark {
+    color-scheme: dark;
+  }
   body {
-    @apply bg-gray-100 text-gray-800 transition-colors duration-300;
+    @apply min-h-screen bg-slate-50 text-slate-900 antialiased transition-colors duration-300;
   }
   .dark body {
-    @apply bg-gray-900 text-gray-200;
+    @apply bg-slate-950 text-slate-100;
   }
   
   /* Applying dark mode styles to specific component backgrounds */
   .dark .bg-white {
-    @apply bg-gray-800;
+    @apply bg-slate-900;
   }
   .dark .bg-gray-50 {
-    @apply bg-gray-700;
+    @apply bg-slate-800;
   }
   .dark .text-gray-800 {
       @apply text-gray-200;
   }
   .dark .text-gray-600 {
-      @apply text-gray-400;
+      @apply text-slate-300;
   }
     .dark .text-gray-500 {
-      @apply text-gray-400;
+      @apply text-slate-400;
   }
     .dark .border-gray-200 {
-      @apply border-gray-600;
+      @apply border-slate-700;
   }
     .dark .border-gray-300 {
-      @apply border-gray-500;
+      @apply border-slate-600;
   }
   .dark .bg-gray-200 {
       @apply bg-gray-600;
@@ -49,5 +55,10 @@
   }
    .dark .text-yellow-800 {
       @apply text-yellow-300;
+  }
+  .dark input,
+  .dark textarea,
+  .dark select {
+    @apply text-slate-100 placeholder:text-slate-500;
   }
 }


### PR DESCRIPTION
## What changed

- improve dark-mode contrast, surfaces, form controls, focus states, alerts, previews, and the theme switcher
- default to the visitor's saved theme or operating-system preference
- move the private personal checklist into its own **My Checklist** tab for PT and legacy packages
- add an always-visible **Invoice** tab with a customer-safe **Coming soon** page and no financial data
- add a customer portal work-in-progress banner
- add the IMS-inspired footer structure with the requested “Developed by Rathobixz Inc.” attribution, beta status, copyright, and working Support/Privacy email links
- update the integration plan and deployment acceptance checks to match the beta UI

## Customer and developer impact

Customers get the same four-section navigation for PT and legacy packages: Overview, Documents, My Checklist, and Invoice. The checklist remains isolated to the current browser session. Invoice data is intentionally not rendered while that area is under development.

The footer design was adapted from `PiyamDev1/pt-portal`'s `GlobalFooter.tsx`; placeholder links were replaced with real office email actions.

## Validation

- `npm run check`
- 4 Node test suites passed
- Vite production build passed (108 modules)
- `git diff --cached --check`
